### PR TITLE
fix: correct KWS Mirth Channel name and description

### DIFF
--- a/src/app/api/kws/page.mdx
+++ b/src/app/api/kws/page.mdx
@@ -162,10 +162,10 @@ sequenceDiagram
 This channel fetches the report submitted in Tiro.health and exports it back to KWS using the KWS Import XML API. It ensures that the report is stored in the patient's record using the correct identifiers, allowing for easy access and retrieval.
 
 <MirthChannel
-  name="Context Launch Channel"
+  name="Report Export Channel"
   version="1.0.0"
   href="mailto:support@tiro.health?subject=KWS%20Mirth%20Channel%20Request&body=Dear%20Tiro.health%20support%2C%0A%0APlease%20send%20me%20the%20latest%20version%20of%20the%20KWS%20Mirth%20channels.%0A%0AThank%20you.%0A"
-  description="Intercept the URL launched from KWS and redirect to Tiro.health with patient and encounter context."
+  description="Retrieve the report from Tiro.health backend and send back to KWS XML Import API"
 />
 
 <details className="mt-2">


### PR DESCRIPTION
Update Report Export Channel component with proper name and description as specified in issue #13.

Fixes #13

Generated with [Claude Code](https://claude.ai/code)