### PR TITLE
Remove Web SDK Integration and API Reference nav sections

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -268,25 +268,6 @@ export const navigation: Array<NavGroup> = [
     ],
   },
   {
-    title: 'Web SDK: Integration',
-    links: [
-      { title: 'React', href: '/form-sdk/web/integration/react' },
-      { title: 'Angular', href: '/form-sdk/web/integration/angular' },
-      { title: 'Vanilla JS', href: '/form-sdk/web/integration/vanilla-js' },
-      { title: 'CDN (No Build)', href: '/form-sdk/web/integration/cdn' },
-    ],
-  },
-  {
-    title: 'Web SDK: API Reference',
-    links: [
-      { title: 'FormFiller', href: '/form-sdk/web/api/form-filler' },
-      { title: 'LaunchContextProvider', href: '/form-sdk/web/api/launch-context-provider' },
-      { title: 'Narrative', href: '/form-sdk/web/api/narrative' },
-      { title: 'ValidationFeedback', href: '/form-sdk/web/api/validation-feedback' },
-      { title: 'SDCClient', href: '/form-sdk/web/api/sdc-client' },
-    ],
-  },
-  {
     title: 'Capture API (managed)',
     links: [
       {


### PR DESCRIPTION
## Summary
- Remove "Web SDK: Integration" navigation section
- Remove "Web SDK: API Reference" navigation section

These sections are being removed from the sidebar navigation.

## Test plan
- [ ] Verify navigation renders correctly without these sections
- [ ] Confirm no broken links in the remaining navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)