### PR TITLE
docs(capture-api): add Data Import & Export pages, scope reports as QuestionnaireResponse

### DIFF
--- a/src/app/api/data-export/page.mdx
+++ b/src/app/api/data-export/page.mdx
@@ -56,24 +56,9 @@ Extract the `response` reference from the query string, then call back into the 
 
 ## Configuring the Redirect
 
-The redirect target can be set in two places. If both are present, the session value takes precedence.
+Set `post_submit_redirect` when you create the session with [`POST /session`](/api/session-management#create-a-session). The redirect is configured per session, so the return location can depend on where the launch came from.
 
-- **Per session** — set `post_submit_redirect` when you create the session with [`POST /session`](/api/session-management#create-a-session). Use this when the return location depends on where the launch came from.
-- **Per task** — add a `post-submit-redirect` input on the [Task](/fhir/Task) with a `valueUrl`. Use this when the destination is a property of the report itself.
-
-```json {{ title: 'Task post-submit-redirect input' }}
-{
-  "type": {
-    "coding": [{
-      "system": "http://fhir.tiro.health/CodeSystem/task-input",
-      "code": "post-submit-redirect"
-    }]
-  },
-  "valueUrl": "https://your-system.example.com/submit"
-}
-```
-
-A matching `post-cancel-redirect` (session field or Task input) controls where the user is sent if they cancel instead of submitting.
+A matching `post_cancel_redirect` controls where the user is sent if they cancel instead of submitting.
 
 ---
 

--- a/src/app/api/data-export/page.mdx
+++ b/src/app/api/data-export/page.mdx
@@ -1,0 +1,261 @@
+export const metadata = {
+  title: 'Data Export',
+  description:
+    'Retrieve completed reports from Tiro.health after submission by handling the post-submit redirect and fetching the QuestionnaireResponse and Composition.',
+}
+
+export const sections = [
+  { title: 'Overview', id: 'overview' },
+  { title: 'The Submit Callback', id: 'the-submit-callback' },
+  { title: 'Configuring the Redirect', id: 'configuring-the-redirect' },
+  { title: 'Fetch the QuestionnaireResponse', id: 'fetch-the-questionnaireresponse' },
+  { title: 'Fetch the Composition', id: 'fetch-the-composition' },
+  { title: 'Native Applications', id: 'native-applications' },
+]
+
+# Data Export
+
+When a practitioner submits a report, Tiro.health persists it to your [data tenant](/guides/data-tenants) and signals your system to fetch the result. This page covers how that callback works and how to retrieve the structured data. {{ className: 'lead' }}
+
+Data export is the final step of a Capture API integration. It follows [Data Import](/api/data-import) and the [context launch](/api/session-management): the user completes the form, clicks submit, and control returns to your application together with everything it needs to pull the report back.
+
+---
+
+## Overview
+
+The submission flow has three parts:
+
+1. **User clicks submit.** The practitioner completes their work in Tiro.health and submits.
+2. **Data is persisted.** The report is saved to your data tenant as a `completed` [QuestionnaireResponse](/fhir/QuestionnaireResponse), and a human-readable narrative is generated.
+3. **Redirect and retrieval.** The user's browser is redirected to a URL you configured. That redirect is both the return path for the user *and* the trigger for your backend to fetch the data.
+
+<Note>
+  The submit callback is a **browser redirect**, not a server-to-server webhook.
+  Your system learns that a report is ready when the user lands back on your
+  configured redirect URL — there is no push notification.
+</Note>
+
+---
+
+## The Submit Callback
+
+On submit, Tiro.health redirects the browser to your configured URL and appends the references of the resources that were just created as query parameters:
+
+```http
+GET https://your-system.example.com/submit?response=QuestionnaireResponse/11427&task=Task/456
+```
+
+| Parameter  | Description                                                             |
+| ---------- | --------------------------------------------------------------------- |
+| `response` | Reference to the completed [QuestionnaireResponse](/fhir/QuestionnaireResponse) — the report. |
+| `task`     | Reference to the [Task](/fhir/Task) that was fulfilled, when the report was launched from a task. |
+
+Extract the `response` reference from the query string, then call back into the FHIR API to retrieve the data. The redirect only tells you *that* a report is ready and *which* one — you still fetch the content yourself.
+
+---
+
+## Configuring the Redirect
+
+The redirect target can be set in two places. If both are present, the session value takes precedence.
+
+- **Per session** — set `post_submit_redirect` when you create the session with [`POST /session`](/api/session-management#create-a-session). Use this when the return location depends on where the launch came from.
+- **Per task** — add a `post-submit-redirect` input on the [Task](/fhir/Task) with a `valueUrl`. Use this when the destination is a property of the report itself.
+
+```json {{ title: 'Task post-submit-redirect input' }}
+{
+  "type": {
+    "coding": [{
+      "system": "http://fhir.tiro.health/CodeSystem/task-input",
+      "code": "post-submit-redirect"
+    }]
+  },
+  "valueUrl": "https://your-system.example.com/submit"
+}
+```
+
+A matching `post-cancel-redirect` (session field or Task input) controls where the user is sent if they cancel instead of submitting.
+
+---
+
+## Fetch the QuestionnaireResponse {{ tag: 'GET', label: '/QuestionnaireResponse' }}
+
+<Row>
+  <Col>
+
+Once you have the `response` id from the redirect, fetch the QuestionnaireResponse. Use `_include` to pull the referenced Patient and Encounter into the same Bundle so you don't need extra round-trips.
+
+The human-readable report is available directly on the response as the generated `text` narrative (XHTML), so most integrations that only need the report text can stop here.
+
+### Common parameters
+
+- `_id` — the QuestionnaireResponse id from the redirect.
+- `_include=QuestionnaireResponse:subject` — include the Patient.
+- `_include=QuestionnaireResponse:encounter` — include the Encounter.
+
+</Col>
+  <Col sticky>
+
+    <CodeGroup title="Request" tag="GET" label="/QuestionnaireResponse">
+
+    ```bash {{ title: 'cURL' }}
+    curl -G https://reports.tiro.health/fhir/r5/QuestionnaireResponse \
+      --data-urlencode "_id=11427" \
+      --data-urlencode "_include=QuestionnaireResponse:subject" \
+      --data-urlencode "_include=QuestionnaireResponse:encounter" \
+      -H "Authorization: Basic {{apikey}}" \
+      -H "Content-Type: application/fhir+json"
+    ```
+
+    ```cs {{ title: 'C#' }}
+    var client = new FhirClient(new Uri("https://reports.tiro.health/fhir/r5"), settings, handler);
+    var searchParams = new SearchParams()
+        .Where("_id=11427")
+        .Include("QuestionnaireResponse:subject")
+        .Include("QuestionnaireResponse:encounter");
+
+    var bundle = client.Search<QuestionnaireResponse>(searchParams);
+    ```
+
+    </CodeGroup>
+
+    ```json {{ title: 'Response (searchset)' }}
+    {
+      "resourceType": "Bundle",
+      "type": "searchset",
+      "total": 1,
+      "entry": [
+        {
+          "fullUrl": "https://reports.tiro.health/fhir/r5/QuestionnaireResponse/11427",
+          "resource": {
+            "resourceType": "QuestionnaireResponse",
+            "id": "11427",
+            "questionnaire": "http://templates.tiro.health/templates/unreadable-unique-id|1.0.1",
+            "status": "completed",
+            "subject": { "reference": "Patient/123" },
+            "encounter": { "reference": "Encounter/456" },
+            "text": {
+              "status": "generated",
+              "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">...report narrative...</div>"
+            }
+          }
+        }
+      ]
+    }
+    ```
+
+  </Col>
+</Row>
+
+<Note>
+  You can also read the report reference back off the Task. Fetching
+  [`GET /Task/{id}`](/fhir/Task#get-a-task) returns the completed
+  QuestionnaireResponse as a `questionnaire-response` output, which is useful when
+  your system tracked the Task id from the import step.
+</Note>
+
+---
+
+## Fetch the Composition {{ tag: 'GET', label: '/Composition/:id' }}
+
+<Row>
+  <Col>
+
+For a structured, document-style view of the report, request the **Composition**. Tiro.health builds it on the fly from the report's content: one `section` per block, each with a `title`, a generated narrative (`text.div`, XHTML), and a stable `code`.
+
+The Composition shares the same id as the report — use the id from the `response` reference.
+
+### Why sections carry codes
+
+Each section has a **fixed code** (LOINC or SNOMED CT) that is stable per template, unlike the `linkId`s inside a QuestionnaireResponse. This lets you map each section directly onto a field in your own system — for example, mapping `section.code = 59776-5` ("Procedure findings") to your *Findings* field. Because the codes are fixed per template, your integration can rely on them.
+
+### Language
+
+The Composition and its section narratives are generated in the language the clinician selected while completing the report. The other translations are dropped, so you always receive one consistent language version per report — never a mix.
+
+  </Col>
+  <Col sticky>
+
+    <CodeGroup title="Request" tag="GET" label="/Composition/11427">
+
+    ```bash {{ title: 'cURL' }}
+    curl -G https://reports.tiro.health/fhir/r5/Composition/11427 \
+      -H "Authorization: Basic {{apikey}}" \
+      -H "Content-Type: application/fhir+json"
+    ```
+
+    ```cs {{ title: 'C#' }}
+    var client = new FhirClient(new Uri("https://reports.tiro.health/fhir/r5"), settings, handler);
+    var composition = client.Read<Composition>("11427");
+    ```
+
+    </CodeGroup>
+
+    ```json {{ title: 'Response' }}
+    {
+      "resourceType": "Composition",
+      "id": "11427",
+      "status": "preliminary",
+      "type": {
+        "coding": [{
+          "system": "http://loinc.org",
+          "code": "11506-3",
+          "display": "Report"
+        }],
+        "text": "Report"
+      },
+      "date": "2025-11-20",
+      "title": "CT scan report",
+      "author": [{ "reference": "Practitioner/1" }],
+      "subject": [{ "reference": "Patient/123" }],
+      "section": [
+        {
+          "title": "Findings",
+          "code": {
+            "coding": [{
+              "system": "http://loinc.org",
+              "code": "59776-5",
+              "display": "Procedure findings Narrative"
+            }]
+          },
+          "text": {
+            "status": "generated",
+            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">...section narrative...</div>"
+          }
+        }
+      ]
+    }
+    ```
+
+  </Col>
+</Row>
+
+### Retrieving the Composition through the Task
+
+If your system tracked the Task from the [import step](/api/data-import), you can fetch the Task and its linked Composition in a single request using `_include`. This is convenient in integration engines (e.g. MIRTH) that key off your own Task identifier:
+
+```bash
+curl -G https://reports.tiro.health/fhir/r5/Task \
+  --data-urlencode "identifier=http://hospital.example.com/tasks|TASK-54321" \
+  --data-urlencode "_include=Task:output:composition" \
+  -H "Authorization: Basic {{apikey}}" \
+  -H "Content-Type: application/fhir+json"
+```
+
+The response is a Bundle containing the Task plus the Composition it references through its `composition` output.
+
+<Note>
+  Tiro.health does not expose a `$document` operation or a server-side PDF/HTML
+  export. The Composition and the QuestionnaireResponse `text` narrative are the
+  rendered outputs available through the API.
+</Note>
+
+---
+
+## Native Applications
+
+For desktop and native integrations, the redirect can use a custom URI scheme instead of an HTTP URL to return the user to your application:
+
+- Windows apps can register [URI activation handlers](https://learn.microsoft.com/en-us/windows/apps/develop/launch/handle-uri-activation).
+- macOS apps can define [custom URL schemes](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app).
+
+When the report runs inside an [embedded browser](/api/embedded-browsers), intercept the redirect navigation to capture the `response` reference programmatically rather than following it as a page load.

--- a/src/app/api/data-import/page.mdx
+++ b/src/app/api/data-import/page.mdx
@@ -1,0 +1,186 @@
+export const metadata = {
+  title: 'Data Import',
+  description:
+    'Pre-load the clinical context Tiro.health needs to start a report by importing Patient, Practitioner and Task resources through the FHIR API.',
+}
+
+export const sections = [
+  { title: 'Overview', id: 'overview' },
+  { title: 'Minimum Resources', id: 'minimum-resources' },
+  { title: 'Import as a Transaction', id: 'import-as-a-transaction' },
+  { title: 'Idempotent Imports', id: 'idempotent-imports' },
+  { title: 'What Happens Next', id: 'what-happens-next' },
+]
+
+# Data Import
+
+Before a practitioner opens Tiro.health, import the clinical context of the report you want them to complete. This lets you pre-fill patient and encounter information so users never have to re-type it. {{ className: 'lead' }}
+
+Data import is the first step of a Capture API integration. Your backend writes a small set of FHIR resources into your [data tenant](/guides/data-tenants) — typically in the background, ahead of the [context launch](/api/session-management) — so that the report is ready to be filled in the moment the user arrives.
+
+---
+
+## Overview
+
+Data import uses the same [FHIR API](/fhir) as the rest of the platform, hosted at `https://reports.tiro.health/fhir/r5`. You can create resources one at a time, but the recommended approach is a single [transaction Bundle](/fhir/Transaction) so that all resources are created atomically and can reference each other.
+
+The goal of the import step is to represent one instruction: *"this practitioner should complete this report for this patient."* In FHIR terms that is a **Task** of type `complete-questionnaire`, pointing at a **Patient**, with the reporting **Practitioner** available as a user in the tenant.
+
+**Authentication required.** All import requests are authenticated. See [Authentication](/api/authentication) for how to obtain credentials.
+
+---
+
+## Minimum Resources
+
+At minimum you import three resources. Only the Patient is strictly required to start a report; importing the Practitioner and Task up front gives the practitioner a ready-to-open entry in their worklist.
+
+| Resource                                       | Required | Purpose                                                                                                                                             |
+| ---------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [**Patient**](/fhir/Patient)                   | Yes      | The subject of the report. A single `identifier` (system + value) is enough; `name` and other demographics are optional but improve the UI.        |
+| [**Practitioner**](/fhir/Practitioner)         | Yes      | The clinician who will author the report. Importing them ensures they exist as a user in the tenant. A single `identifier` is enough.              |
+| [**Task**](/fhir/Task)                         | Yes      | The `complete-questionnaire` order that appears in the practitioner's worklist. References the Patient via `for`.                                   |
+| [**Encounter**](/fhir/Encounter)               | Optional | Links the report to a specific visit. Referenced from the Task via `encounter` and carried onto the resulting QuestionnaireResponse.               |
+
+<Note>
+  The reporting clinician is imported as a Practitioner so that they exist as a
+  user in your data tenant. The Task itself is not linked to the Practitioner —
+  the acting practitioner is the authenticated user of the session that opens the
+  report. See the [Task](/fhir/Task) reference for the full set of supported
+  fields.
+</Note>
+
+---
+
+## Import as a Transaction {{ tag: 'POST', label: '/fhir/r5' }}
+
+Post a `transaction` Bundle to the FHIR API root. Resources reference each other by `fullUrl` using `urn:uuid:` placeholders; Tiro.health resolves those to real IDs and rewrites the references for you, regardless of the order the entries appear in.
+
+<Row>
+  <Col>
+
+The Bundle below imports a Patient, a Practitioner, and a draft `complete-questionnaire` Task in one atomic operation. If any entry fails, the whole transaction is rolled back.
+
+Because the Task's `code.text` becomes the title shown in the worklist, set it to something the practitioner will recognise (e.g. *"CT scan report"*).
+
+  </Col>
+  <Col sticky>
+
+    <CodeGroup title="Import Bundle" tag="POST" label="/fhir/r5">
+
+    ```bash {{ title: 'cURL' }}
+    curl -X POST https://reports.tiro.health/fhir/r5 \
+      -H "Authorization: Basic {{apikey}}" \
+      -H "Content-Type: application/fhir+json" \
+      -d '{
+        "resourceType": "Bundle",
+        "type": "transaction",
+        "entry": [
+          {
+            "fullUrl": "urn:uuid:patient-001",
+            "resource": {
+              "resourceType": "Patient",
+              "identifier": [{
+                "system": "http://hospital.example.com/patients",
+                "value": "PAT-12345"
+              }],
+              "name": [{"family": "Smith", "given": ["John"]}]
+            },
+            "request": { "method": "POST", "url": "Patient" }
+          },
+          {
+            "fullUrl": "urn:uuid:practitioner-001",
+            "resource": {
+              "resourceType": "Practitioner",
+              "identifier": [{
+                "system": "http://hospital.example.com/practitioners",
+                "value": "PRAC-67890"
+              }],
+              "name": [{"family": "Jones", "given": ["Sarah"]}]
+            },
+            "request": { "method": "POST", "url": "Practitioner" }
+          },
+          {
+            "fullUrl": "urn:uuid:task-001",
+            "resource": {
+              "resourceType": "Task",
+              "intent": "order",
+              "status": "draft",
+              "identifier": [{
+                "system": "http://hospital.example.com/tasks",
+                "value": "TASK-54321"
+              }],
+              "description": "Complete the CT scan report for John Smith.",
+              "code": {
+                "text": "CT scan report",
+                "coding": [{
+                  "system": "http://fhir.tiro.health/CodeSystem/task-type",
+                  "code": "complete-questionnaire"
+                }]
+              },
+              "for": { "reference": "urn:uuid:patient-001" }
+            },
+            "request": { "method": "POST", "url": "Task" }
+          }
+        ]
+      }'
+    ```
+
+    </CodeGroup>
+
+    ```json {{ title: 'Response (transaction-response)' }}
+    {
+      "resourceType": "Bundle",
+      "type": "transaction-response",
+      "entry": [
+        { "response": { "status": "201 Created", "location": "Patient/1" } },
+        { "response": { "status": "201 Created", "location": "Practitioner/1" } },
+        { "response": { "status": "201 Created", "location": "Task/1" } }
+      ]
+    }
+    ```
+
+  </Col>
+</Row>
+
+Each response entry carries a `location` with the assigned ID. Store the Task location (`Task/1`) if you want to track the report's progress or [fetch the result](/api/data-export) later.
+
+---
+
+## Idempotent Imports
+
+Because imports usually run in the background — and may run more than once for the same patient — use **conditional create** so repeated imports don't create duplicates. Add an `ifNoneExist` query on the entry: if a resource already matches, Tiro.health reuses it instead of creating a new one.
+
+```json {{ title: 'Conditional create entry' }}
+{
+  "fullUrl": "urn:uuid:patient-001",
+  "resource": {
+    "resourceType": "Patient",
+    "identifier": [{
+      "system": "http://hospital.example.com/patients",
+      "value": "PAT-12345"
+    }]
+  },
+  "request": {
+    "method": "POST",
+    "url": "Patient",
+    "ifNoneExist": "identifier=http://hospital.example.com/patients|PAT-12345"
+  }
+}
+```
+
+Alternatively, use a conditional update (`PUT Patient?identifier=...`) to upsert a resource — creating it if it does not exist, or updating the matching resource in place. The same pattern applies to Encounter and Practitioner. Matching is always done on the external `identifier` you provided, so make sure every resource carries a stable identifier from your system. See [Linking resources to your internal identifiers](/fhir/tips#linking-resources-to-your-internal-identifiers).
+
+---
+
+## What Happens Next
+
+A `complete-questionnaire` Task moves through a short lifecycle as it is prepared and filled in:
+
+1. **`draft`** — imported without a questionnaire. The report is not yet ready to open.
+2. **`ready`** — a questionnaire (form template) has been attached, either through the API or by the practitioner choosing one in the UI.
+3. **`in-progress`** — the practitioner has started filling in the form.
+4. **`completed`** — the form has been submitted and processed.
+
+You can attach the questionnaire yourself by including a `questionnaire` input on the Task, or let the practitioner pick a template when they open the report. See the [Task](/fhir/Task) reference for input types and lifecycle operations.
+
+Once the context is imported, hand the user over to Tiro.health with a [context launch](/api/session-management), and retrieve the finished report through the [Data Export](/api/data-export) step.

--- a/src/app/api/page.mdx
+++ b/src/app/api/page.mdx
@@ -30,7 +30,7 @@ Here's how a typical integration with Tiro.health API looks like:
 
 ### Data Import
 Tiro.health requires minimal patient data to associate with the QuestionnaireResponse. At minimum, a patient resource with a single identifier is required. You can optionally provide an encounter resource as well. This data can be imported in your data tenant in the background before users are writing structured report to prevent users from having to enter patient data manually.
-Learn more about available APIs in the [FHIR API](./fhir) section.
+See the [Data Import](./api/data-import) guide for the step-by-step flow, or learn more about available APIs in the [FHIR API](./fhir) section.
 
 <details>
     <summary>**Example: FHIR Transaction**</summary>
@@ -92,9 +92,6 @@ curl -X POST https://reports.tiro.health/fhir/r5 \
           },
           "for": {
             "reference": "urn:uuid:patient-001"
-          },
-          "owner": {
-            "reference": "urn:uuid:practitioner-001"
           }
         },
         "request": {
@@ -143,4 +140,7 @@ The redirect URL can be configured per session and supports different integratio
   - Mac apps can define [custom URL schemes](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app)
 
 The redirect not only brings the user back to the host application but also signals that the data is ready to be retrieved from the data tenant.
+
+See the [Data Export](./api/data-export) guide for how to handle the callback and fetch the completed QuestionnaireResponse and Composition.
+
 ![Sketch illustrating the submission step.](/submission.svg)

--- a/src/app/api/session-management/page.mdx
+++ b/src/app/api/session-management/page.mdx
@@ -79,7 +79,7 @@ Creates a new authenticated session for an end-user. This endpoint can optionall
 
 <Properties>
   <Property name="scope" type="string">
-    Space-separated list of requested scopes (e.g., `"patient/Patient.read patient/Observation.write"`). These scopes control what data the user can access during the session.
+    Space-separated list of requested scopes (e.g., `"patient/Patient.read patient/QuestionnaireResponse.write"`). These scopes control what data the user can access during the session.
   </Property>
   <Property name="patient" type="integer">
     FHIR server ID of the patient to associate with this session.
@@ -111,7 +111,7 @@ Creates a new authenticated session for an end-user. This endpoint can optionall
       -H "Authorization: Bearer <access_token>" \
       -H "Content-Type: application/json" \
       -d '{
-        "scope": "patient/Patient.read patient/Observation.write",
+        "scope": "patient/Patient.read patient/QuestionnaireResponse.write",
         "patient": 123,
         "deployment_mode": "embedded"
       }'
@@ -123,7 +123,7 @@ Creates a new authenticated session for an end-user. This endpoint can optionall
         new AuthenticationHeaderValue("Bearer", accessToken);
 
     var payload = new {
-      scope = "patient/Patient.read patient/Observation.write",
+      scope = "patient/Patient.read patient/QuestionnaireResponse.write",
       patient = 123,
       deployment_mode = "embedded"
     };
@@ -277,7 +277,7 @@ Retrieves information about the current authenticated session. This endpoint req
       "deployment_mode": "embedded",
       "fhir_server": {
         "address": "https://fhir.hospital.org/R4",
-        "scope": ["patient/Patient.read", "patient/Observation.write"]
+        "scope": ["patient/Patient.read", "patient/QuestionnaireResponse.write"]
       }
     }
     ```
@@ -343,11 +343,14 @@ Scopes follow the FHIR SMART on FHIR format: `<context>/<resourceType>.<action>`
 - `system/<resourceType>.<action>` - System-wide access to specific resource types
 
 **Examples:**
+- `patient/QuestionnaireResponse.write` - Write access to reports (QuestionnaireResponses) in the patient's compartment
+- `patient/QuestionnaireResponse.read` - Read access to reports in the patient's compartment
 - `patient/Patient.read` - Read access to patient resources in the patient's compartment
-- `patient/Observation.write` - Write access to observations in the patient's compartment
 - `patient/Encounter.read` - Read access to encounters in the patient's compartment
-- `system/Patient.read` - System-wide read access to all patient resources
-- `patient/Patient.read patient/Observation.write` - Multiple scopes can be combined
+- `system/QuestionnaireResponse.read` - System-wide read access to all reports
+- `patient/Patient.read patient/QuestionnaireResponse.write` - Multiple scopes can be combined
+
+Reports authored in Tiro.health are stored as FHIR `QuestionnaireResponse` resources, so `QuestionnaireResponse` is the resource type you scope to control read and write access to captured data. `Patient`, `Encounter`, and `Practitioner` are the supporting context resources and are granted read-only.
 
 ### How Scopes Work
 
@@ -365,12 +368,12 @@ When a session is created with scopes:
 curl -X POST https://reports.tiro.health/session \
   -H "Content-Type: application/json" \
   -d '{
-    "scope": "patient/Patient.read patient/Encounter.read patient/Observation.read",
+    "scope": "patient/Patient.read patient/Encounter.read patient/QuestionnaireResponse.read",
     "patient": 123
   }'
 ```
 
-In this session, the user can read patient, encounter, and observation data but cannot modify anything. Any attempt to create or update resources will be denied.
+In this session, the user can read patient, encounter, and report data but cannot modify anything. Any attempt to create or update resources will be denied.
 
 ---
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -281,8 +281,16 @@ export const navigation: Array<NavGroup> = [
         href: '/api/authentication',
       },
       {
+        title: 'Data Import',
+        href: '/api/data-import',
+      },
+      {
         title: 'Session Management',
         href: '/api/session-management',
+      },
+      {
+        title: 'Data Export',
+        href: '/api/data-export',
       },
       {
         title: 'Embedded Browsers',


### PR DESCRIPTION
## What

Adds two new **Capture API** guides for the two ends of the integration flow, and corrects the scope documentation.

### New pages
- **Data Import** (`/api/data-import`) — pre-loading the clinical context needed to start a report. Covers the minimum resources (Patient, Practitioner, Task), an atomic FHIR transaction Bundle with `urn:uuid` cross-references, idempotent imports via conditional create (`ifNoneExist` / `PUT ?identifier`), and the Task lifecycle.
- **Data Export** (`/api/data-export`) — retrieving a completed report. Covers the post-submit **redirect callback** (`?response=QuestionnaireResponse/{id}&task=Task/{id}`), fetching the QuestionnaireResponse (with `_include`), and fetching the Composition.

### Scope correction
- Session Management scope examples now use **`QuestionnaireResponse`** instead of `Observation`. `QuestionnaireResponse` is the resource type that actually carries an enforced scope policy for report data; `Observation` scopes are inert. Added a note clarifying Patient/Encounter/Practitioner are read-only context resources.
- Removed the unsupported `Task.owner` field from the overview import example (the backend silently ignores it).
- Wired both new pages into the Capture API navigation in flow order: Authentication → **Data Import** → Session Management → **Data Export** → Embedded Browsers.

## Grounding

Both pages were written against the actual backend/frontend implementation. The Composition section reflects the production integration with Europa Ziekenhuizen: **stable per-section LOINC/SNOMED codes** (so hosts map each section directly to a DB field, unlike QuestionnaireResponse linkIds), **language pinning** to the clinician's choice, and the `GET Task?identifier=...&_include=Task:output:composition` retrieval pattern used in MIRTH.

## Verification

`npm run build` succeeds — 44 static pages export, both new pages render, and the nav links appear on every page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)