### PR TITLE
docs: remove the OAuth2 bearer-token flow, document the API key auth that actually works

### DIFF
--- a/src/app/api/authentication/page.mdx
+++ b/src/app/api/authentication/page.mdx
@@ -1,73 +1,40 @@
 export const metadata = {
   title: 'API Authentication',
   description:
-    'Learn how to authenticate with the Tiro.health API using OAuth2 client credentials flow for secure machine-to-machine communication.',
+    'Learn how to authenticate with the Tiro.health Capture API using your API key over HTTP Basic authentication.',
 }
 
 export const sections = [
   { title: 'Overview', id: 'overview' },
-  { title: 'Authentication Flow', id: 'authentication-flow' },
   { title: 'Obtain Client Credentials', id: 'obtain-client-credentials' },
-  { title: 'Request Access Token', id: 'request-access-token' },
-  { title: 'Use Access Token', id: 'use-access-token' },
-  { title: 'Token Expiration', id: 'token-expiration' },
+  { title: 'Authenticate a Request', id: 'authenticate-a-request' },
+  { title: 'End-user Identification', id: 'end-user-identification' },
   { title: 'Security Best Practices', id: 'security-best-practices' },
 ]
 
 # API Authentication
 
-Authenticate your API requests to Tiro.health using OAuth2 client credentials flow for secure machine-to-machine communication. {{ className: 'lead' }}
+Authenticate your Capture API requests with your API key, sent as [HTTP Basic](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme) credentials. {{ className: 'lead' }}
 
 ---
 
 ## Overview
 
-The Tiro.health Capture API uses **OAuth2 client credentials flow** for authentication. This is the standard approach for server-to-server communication where your application needs to access the API on behalf of itself, not a specific user.
+The Capture API uses **HTTP Basic authentication** with an API key: the base64 encoding of `client_id:client_secret`. There is no token exchange — you send the key on every request.
 
-### When to Use OAuth2 Client Credentials
-
-Use OAuth2 client credentials authentication when you need to:
+The same credentials authenticate the [FHIR API](/fhir/authentication), so a single API key covers a whole integration:
 
 - **Create sessions** programmatically via the [Session Management API](/api/session-management)
-- **Access FHIR resources** for data import and export
-- **Integrate with EHR/LIS systems** in the background without user interaction
-- **Automate workflows** that interact with Tiro.health programmatically
+- **Import and export data** through the FHIR API
+- **Integrate with EHR/LIS systems** in the background, without user interaction
 
-### Key Benefits
-
-- **Secure**: Client credentials are never exposed in URLs or browser contexts
-- **Standard**: Follows OAuth2 RFC 6749 specifications
-- **Token-based**: Access tokens can be cached and reused until expiration
-- **Flexible**: Works with any HTTP client or programming language
-
----
-
-## Authentication Flow
-
-The OAuth2 client credentials flow follows this sequence:
-
-```mermaid
-sequenceDiagram
-    participant App as Your Application
-    participant Auth as Tiro.health<br/>Auth Server
-    participant API as Tiro.health<br/>API
-
-    App->>Auth: POST /oauth/token<br/>(client credentials)
-    Auth-->>App: Access Token
-    App->>API: API Request<br/>(Bearer Token)
-    API-->>App: API Response
-```
-
-1. **Obtain credentials**: Get your `client_id` and `client_secret` from Tiro.health
-2. **Request token**: Exchange credentials for an access token at the token endpoint
-3. **Use token**: Include the access token in the `Authorization` header of API requests
-4. **Refresh when expired**: Request a new token when the current one expires
+Requests are made by your backend. Never send your API key to a browser or a mobile app.
 
 ---
 
 ## Obtain Client Credentials
 
-Before you can authenticate, you need to obtain OAuth2 client credentials from Tiro.health:
+Before you can authenticate, obtain client credentials from Tiro.health:
 
 1. Contact your Tiro.health account manager or support team
 2. Provide information about your integration:
@@ -75,161 +42,36 @@ Before you can authenticate, you need to obtain OAuth2 client credentials from T
    - Integration purpose (e.g., EHR integration, data import)
    - Expected API usage
 3. Receive your credentials:
-   - `client_id` - Your application's unique identifier
-   - `client_secret` - Your application's secret key (keep this secure!)
+   - `client_id` — your application's unique identifier
+   - `client_secret` — your application's secret key (keep this secure!)
 
 **Important**: Store your `client_secret` securely. Never commit it to version control or expose it in client-side code.
 
 ---
 
-## Request Access Token {{ tag: 'POST', label: '/oauth/token' }}
+## Authenticate a Request
 
 <Row>
   <Col>
 
-Exchange your client credentials for an access token by making a POST request to the token endpoint.
+Send your credentials in the `Authorization` header, using the `Basic` scheme:
 
-### Request Parameters
+```
+Authorization: Basic base64(client_id:client_secret)
+```
 
-<Properties>
-  <Property name="grant_type" type="string" required>
-    Must be `"client_credentials"` for machine-to-machine authentication.
-  </Property>
-  <Property name="client_id" type="string" required>
-    Your application's client identifier provided by Tiro.health.
-  </Property>
-  <Property name="client_secret" type="string" required>
-    Your application's secret key provided by Tiro.health.
-  </Property>
-</Properties>
+Most HTTP clients build this header for you — cURL's `-u` flag, or `AuthenticationHeaderValue("Basic", …)` in .NET.
 
-### Response Fields
-
-<Properties>
-  <Property name="access_token" type="string">
-    The access token to use for authenticated API requests.
-  </Property>
-  <Property name="token_type" type="string">
-    Always `"Bearer"` - indicates the token should be used in the Authorization header.
-  </Property>
-  <Property name="expires_in" type="integer">
-    Number of seconds until the token expires (typically 3600 = 1 hour).
-  </Property>
-</Properties>
+The API key belongs to a [data tenant](/guides/data-tenants), which determines what data the request can reach.
 
   </Col>
   <Col sticky>
 
-    <CodeGroup title="Request Access Token">
+    <CodeGroup title="Authenticated Request">
 
     ```bash {{ title: 'cURL' }}
-    curl -X POST https://auth.tiro.health/oauth/token \
-      -H "Content-Type: application/x-www-form-urlencoded" \
-      -d "grant_type=client_credentials" \
-      -d "client_id=your_client_id" \
-      -d "client_secret=your_client_secret"
-    ```
-
-    ```csharp {{ title: 'C#' }}
-    using System.Net.Http;
-    using System.Text.Json;
-
-    var client = new HttpClient();
-    var content = new FormUrlEncodedContent(new[]
-    {
-        new KeyValuePair<string, string>("grant_type", "client_credentials"),
-        new KeyValuePair<string, string>("client_id", "your_client_id"),
-        new KeyValuePair<string, string>("client_secret", "your_client_secret")
-    });
-
-    var response = await client.PostAsync(
-        "https://auth.tiro.health/oauth/token",
-        content
-    );
-
-    var tokenResponse = await response.Content.ReadFromJsonAsync<TokenResponse>();
-    string accessToken = tokenResponse.AccessToken;
-    ```
-
-    ```javascript {{ title: 'JavaScript' }}
-    const response = await fetch('https://auth.tiro.health/oauth/token', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: new URLSearchParams({
-        grant_type: 'client_credentials',
-        client_id: 'your_client_id',
-        client_secret: 'your_client_secret',
-      }),
-    });
-
-    const data = await response.json();
-    const accessToken = data.access_token;
-    ```
-
-    ```python {{ title: 'Python' }}
-    import requests
-
-    response = requests.post(
-        'https://auth.tiro.health/oauth/token',
-        data={
-            'grant_type': 'client_credentials',
-            'client_id': 'your_client_id',
-            'client_secret': 'your_client_secret',
-        }
-    )
-
-    token_data = response.json()
-    access_token = token_data['access_token']
-    ```
-
-    </CodeGroup>
-
-    ```json {{ title: 'Response (200 OK)' }}
-    {
-      "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
-      "token_type": "Bearer",
-      "expires_in": 3600
-    }
-    ```
-
-  </Col>
-</Row>
-
----
-
-## Use Access Token
-
-Once you have an access token, include it in the `Authorization` header of your API requests using the `Bearer` scheme.
-
-### Authorization Header Format
-
-```
-Authorization: Bearer <access_token>
-```
-
-The token grants you access to all Tiro.health API endpoints based on your client's permissions, including:
-
-- **Session Management API** - Create and manage user sessions
-- **FHIR API** - Access patient data, questionnaires, and responses
-- **Task API** - Create and manage tasks for users
-
-<Row>
-  <Col>
-
-### Example: Using the Token
-
-Include the Bearer token in the Authorization header of your requests.
-
-  </Col>
-  <Col sticky>
-
-    <CodeGroup title="Example API Request with Token">
-
-    ```bash {{ title: 'cURL' }}
-    curl https://reports.tiro.health/session \
-      -H "Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..." \
+    curl -X POST https://auth.tiro.health/sessions \
+      -u "client_id:client_secret" \
       -H "Content-Type: application/json" \
       -d '{
         "scope": "patient/Patient.read",
@@ -239,8 +81,11 @@ Include the Bearer token in the Authorization header of your requests.
 
     ```csharp {{ title: 'C#' }}
     var client = new HttpClient();
+    var credentials = Convert.ToBase64String(
+        Encoding.UTF8.GetBytes($"{clientId}:{clientSecret}")
+    );
     client.DefaultRequestHeaders.Authorization =
-        new AuthenticationHeaderValue("Bearer", accessToken);
+        new AuthenticationHeaderValue("Basic", credentials);
 
     var payload = new {
         scope = "patient/Patient.read",
@@ -248,16 +93,20 @@ Include the Bearer token in the Authorization header of your requests.
     };
 
     var response = await client.PostAsJsonAsync(
-        "https://reports.tiro.health/session",
+        "https://auth.tiro.health/sessions",
         payload
     );
     ```
 
     ```javascript {{ title: 'JavaScript' }}
-    const response = await fetch('https://reports.tiro.health/session', {
+    const credentials = Buffer.from(
+      `${clientId}:${clientSecret}`
+    ).toString('base64');
+
+    const response = await fetch('https://auth.tiro.health/sessions', {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${accessToken}`,
+        'Authorization': `Basic ${credentials}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
@@ -270,20 +119,13 @@ Include the Bearer token in the Authorization header of your requests.
     ```python {{ title: 'Python' }}
     import requests
 
-    headers = {
-        'Authorization': f'Bearer {access_token}',
-        'Content-Type': 'application/json',
-    }
-
-    payload = {
-        'scope': 'patient/Patient.read',
-        'patient': 123,
-    }
-
     response = requests.post(
-        'https://reports.tiro.health/session',
-        headers=headers,
-        json=payload
+        'https://auth.tiro.health/sessions',
+        auth=(client_id, client_secret),
+        json={
+            'scope': 'patient/Patient.read',
+            'patient': 123,
+        },
     )
     ```
 
@@ -294,138 +136,19 @@ Include the Bearer token in the Authorization header of your requests.
 
 ---
 
-## Token Expiration
+## End-user Identification
 
-Access tokens are temporary and expire after a set period (typically 1 hour).
+An API key authenticates your *system*, not a person. Some requests need to be attributed to a specific end-user — the practitioner filling in a report, for example.
 
-### Handling Token Expiration
+Add the `X-User-Id` header to act as that user. Its value is an **identifier token**: the practitioner's identifier `system` and `value` joined with a pipe (`|`), matching an identifier on a [Practitioner](/fhir/Practitioner#create-a-new-practitioner) you created.
 
-When a token expires, API requests will return a `401 Unauthorized` error:
-
-```json
-{
-  "error": "invalid_token",
-  "error_description": "The access token expired"
-}
+```bash
+curl https://reports.tiro.health/fhir/r5/Patient \
+  -u "client_id:client_secret" \
+  -H "X-User-Id: http://myhospital.org/clinical-staff/user-ids|123"
 ```
 
-**Recommended approach:**
-
-1. **Cache the token** - Store the access token and its expiration time
-2. **Check expiration** - Before making API requests, verify the token hasn't expired
-3. **Request new token** - When expired, request a new token using your client credentials
-4. **Retry request** - Retry the failed API request with the new token
-
-### Example: Token Management
-
-<CodeGroup title="Token Caching and Refresh">
-
-```csharp {{ title: 'C#' }}
-public class TokenManager
-{
-    private string _accessToken;
-    private DateTime _expiresAt;
-    private readonly HttpClient _client = new HttpClient();
-
-    public async Task<string> GetValidTokenAsync()
-    {
-        if (DateTime.UtcNow >= _expiresAt)
-        {
-            await RefreshTokenAsync();
-        }
-        return _accessToken;
-    }
-
-    private async Task RefreshTokenAsync()
-    {
-        var content = new FormUrlEncodedContent(new[]
-        {
-            new KeyValuePair<string, string>("grant_type", "client_credentials"),
-            new KeyValuePair<string, string>("client_id", "your_client_id"),
-            new KeyValuePair<string, string>("client_secret", "your_client_secret")
-        });
-
-        var response = await _client.PostAsync(
-            "https://auth.tiro.health/oauth/token",
-            content
-        );
-
-        var tokenData = await response.Content.ReadFromJsonAsync<TokenResponse>();
-        _accessToken = tokenData.AccessToken;
-        _expiresAt = DateTime.UtcNow.AddSeconds(tokenData.ExpiresIn - 60); // 60s buffer
-    }
-}
-```
-
-```javascript {{ title: 'JavaScript' }}
-class TokenManager {
-  constructor(clientId, clientSecret) {
-    this.clientId = clientId;
-    this.clientSecret = clientSecret;
-    this.accessToken = null;
-    this.expiresAt = null;
-  }
-
-  async getValidToken() {
-    if (!this.accessToken || Date.now() >= this.expiresAt) {
-      await this.refreshToken();
-    }
-    return this.accessToken;
-  }
-
-  async refreshToken() {
-    const response = await fetch('https://auth.tiro.health/oauth/token', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        grant_type: 'client_credentials',
-        client_id: this.clientId,
-        client_secret: this.clientSecret,
-      }),
-    });
-
-    const data = await response.json();
-    this.accessToken = data.access_token;
-    // Subtract 60 seconds as buffer
-    this.expiresAt = Date.now() + (data.expires_in - 60) * 1000;
-  }
-}
-```
-
-```python {{ title: 'Python' }}
-import requests
-from datetime import datetime, timedelta
-
-class TokenManager:
-    def __init__(self, client_id, client_secret):
-        self.client_id = client_id
-        self.client_secret = client_secret
-        self.access_token = None
-        self.expires_at = None
-
-    def get_valid_token(self):
-        if not self.access_token or datetime.now() >= self.expires_at:
-            self.refresh_token()
-        return self.access_token
-
-    def refresh_token(self):
-        response = requests.post(
-            'https://auth.tiro.health/oauth/token',
-            data={
-                'grant_type': 'client_credentials',
-                'client_id': self.client_id,
-                'client_secret': self.client_secret,
-            }
-        )
-
-        token_data = response.json()
-        self.access_token = token_data['access_token']
-        # Subtract 60 seconds as buffer
-        expires_in = token_data['expires_in'] - 60
-        self.expires_at = datetime.now() + timedelta(seconds=expires_in)
-```
-
-</CodeGroup>
+Without the header, the request acts as the service account tied to your API key. See [FHIR API Authentication](/fhir/authentication#end-user-identification-in-machine-to-machine-communication) for details.
 
 ---
 
@@ -434,42 +157,32 @@ class TokenManager:
 ### Protect Your Client Credentials
 
 - **Never commit** `client_secret` to version control (use environment variables or secret management)
-- **Never expose** credentials in client-side code or public repositories
-- **Use HTTPS only** - Always use encrypted connections when transmitting credentials
-- **Rotate regularly** - Change your credentials periodically or if compromised
-
-### Secure Token Storage
-
-- **Server-side only** - Never send access tokens to client browsers or mobile apps
-- **Memory storage** - Store tokens in memory rather than persistent storage when possible
-- **Encrypt at rest** - If you must persist tokens, encrypt them
-- **Clear on logout** - Dispose of tokens properly when no longer needed
+- **Never expose** credentials in client-side code, browsers, mobile apps, or public repositories
+- **Use HTTPS only** — always use encrypted connections when transmitting credentials
+- **Rotate regularly** — change your credentials periodically or if compromised
 
 ### API Request Security
 
-- **HTTPS only** - All API requests must use HTTPS
-- **Validate responses** - Check for authentication errors and handle them appropriately
-- **Rate limiting** - Implement backoff strategies for rate-limited responses
-- **Minimal permissions** - Request only the access your application needs
+- **Server-side only** — the API key is a backend credential; the end-user's browser gets a session cookie instead, via [session handover](/api/session-management#session-handover)
+- **Validate responses** — check for authentication errors and handle them appropriately
+- **Rate limiting** — implement backoff strategies for rate-limited responses
+- **Minimal permissions** — request only the scopes your integration needs
 
 ### Monitoring and Auditing
 
-- **Log access** - Keep audit logs of API access (but never log tokens or credentials)
-- **Monitor usage** - Track API usage patterns to detect anomalies
-- **Alert on failures** - Set up alerts for repeated authentication failures
-- **Review regularly** - Periodically review client access and permissions
+- **Log access** — keep audit logs of API access, but never log credentials
+- **Monitor usage** — track API usage patterns to detect anomalies
+- **Alert on failures** — set up alerts for repeated authentication failures
+- **Review regularly** — periodically review client access and permissions
 
 ---
 
 ## Next Steps
 
-Now that you understand OAuth2 authentication, you can:
+Now that you can authenticate, you can:
 
-- **[Create sessions](/api/session-management)** - Use the Session Management API to create authenticated user sessions
-- **[Access FHIR resources](/fhir)** - Query and modify patient data via the FHIR API
-- **[Import data](/api)** - Set up background data synchronization with your EHR/LIS
+- **[Create sessions](/api/session-management)** — hand an authenticated user over to Tiro.health
+- **[Access FHIR resources](/fhir)** — query and modify patient data via the FHIR API
+- **[Import data](/api/data-import)** — set up background data synchronization with your EHR/LIS
 
-For alternative authentication methods, see:
-
-- **[FHIR API Authentication](/fhir/authentication)** - Basic authentication and user identification
-- **[SMART on FHIR](/smart-on-fhir)** - User-delegated access with context launch
+For user-delegated access with context launch, see **[SMART on FHIR](/smart-on-fhir)**.

--- a/src/app/api/authentication/page.mdx
+++ b/src/app/api/authentication/page.mdx
@@ -209,16 +209,18 @@ Once you have an access token, include it in the `Authorization` header of your 
 Authorization: Bearer <access_token>
 ```
 
-<Note>
-  This token is only accepted by the deprecated `POST /session` endpoint. It does **not** authenticate the current [Session Management API](/api/session-management) or the [FHIR API](/fhir/authentication) — both use [HTTP Basic](/fhir/authentication#basic-authentication-api-key) with your API key. Unless you are maintaining an existing integration against `/session`, you do not need this flow.
-</Note>
+The token grants you access to all Tiro.health API endpoints based on your client's permissions, including:
+
+- **Session Management API** - Create and manage user sessions
+- **FHIR API** - Access patient data, questionnaires, and responses
+- **Task API** - Create and manage tasks for users
 
 <Row>
   <Col>
 
 ### Example: Using the Token
 
-Include the Bearer token in the Authorization header of your request to the deprecated `POST /session` endpoint.
+Include the Bearer token in the Authorization header of your requests.
 
   </Col>
   <Col sticky>
@@ -249,6 +251,40 @@ Include the Bearer token in the Authorization header of your request to the depr
         "https://reports.tiro.health/session",
         payload
     );
+    ```
+
+    ```javascript {{ title: 'JavaScript' }}
+    const response = await fetch('https://reports.tiro.health/session', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        scope: 'patient/Patient.read',
+        patient: 123,
+      }),
+    });
+    ```
+
+    ```python {{ title: 'Python' }}
+    import requests
+
+    headers = {
+        'Authorization': f'Bearer {access_token}',
+        'Content-Type': 'application/json',
+    }
+
+    payload = {
+        'scope': 'patient/Patient.read',
+        'patient': 123,
+    }
+
+    response = requests.post(
+        'https://reports.tiro.health/session',
+        headers=headers,
+        json=payload
+    )
     ```
 
     </CodeGroup>

--- a/src/app/api/session-management/page.mdx
+++ b/src/app/api/session-management/page.mdx
@@ -54,7 +54,7 @@ https://auth.tiro.health
 The API key must belong to a [data tenant](/guides/data-tenants), otherwise session creation fails with `403`.
 
 <Note>
-  If you are currently calling the singular `/session` endpoints on `reports.tiro.health` with an OAuth2 bearer token, see [Migrating from /session](#migrating-from-session). Those endpoints are deprecated.
+  If you are currently calling the singular `/session` endpoints on `reports.tiro.health`, see [Migrating from /session](#migrating-from-session). Those endpoints are deprecated.
 </Note>
 
 ---
@@ -593,11 +593,10 @@ The singular `/session` endpoints are **deprecated**. They still work, but new i
 | Handover | `POST /session/$handover` | `GET` or `POST /sessions/$handover` |
 | Read | `GET /session` (cookie) | `GET /sessions/{id}` (API key) or `GET /sessions/current` (cookie) |
 | Delete | `DELETE /session` (cookie) | `DELETE /sessions/{id}` (API key) |
-| Auth | OAuth2 bearer token | [HTTP Basic](/fhir/authentication#basic-authentication-api-key) API key |
 
-Three things change beyond the path:
+**Authentication does not change.** You keep authenticating with your API key over [HTTP Basic](/fhir/authentication#basic-authentication-api-key), exactly as before.
 
-**The OAuth2 step disappears.** The old flow exchanged your credentials at `POST /oauth/token` for a bearer token, then passed that to `POST /session`. That token was really a session token in disguise. Now you authenticate `POST /sessions` with your API key directly — there is no token exchange.
+Two things change beyond the path:
 
 **The handover token is returned in the response body.** `POST /sessions` responds `201` with `handover_token` in the JSON. You no longer read it off a cookie.
 

--- a/src/app/fhir/authentication/page.mdx
+++ b/src/app/fhir/authentication/page.mdx
@@ -1,12 +1,12 @@
 export const metadata = {
   title: 'Authentication',
   description:
-    'In this guide, we’ll look at how authentication works. Atticus offers two ways to authenticate your API requests: Basic authentication and OAuth2 with a token.',
+    'In this guide, we’ll look at how authentication works. Atticus authenticates API requests with an API key over Basic authentication.',
 }
 
 # Authentication
 
-You'll need to authenticate your requests to access any of the endpoints in the Atticus API. In this guide, we'll look at how authentication works. Atticus offers two ways to authenticate your API requests: [Basic authentication](#basic-authentication-api-key) and OAuth2 with a token. {{ className: 'lead' }}
+You'll need to authenticate your requests to access any of the endpoints in the Atticus API. In this guide, we'll look at how authentication works. Atticus authenticates your API requests with an API key, sent as [Basic authentication](#basic-authentication-api-key). {{ className: 'lead' }}
 If requests must be performed as a specific end-user, an extra header is needed to identify that user. This is the `X-User-Id` header. This header is used to identify the user in the context of the session. This header is only needed when the session is created in the background.
 
 ## Basic authentication (API key)
@@ -56,14 +56,8 @@ The notation used for the `X-User-Id` header is an **identifier token**. An iden
 The identifier used needs to match with an identifier passed as part of a [`POST Practitioner` request](./fhir/Practitioner#create-a-new-practitioner).
 In headers we need a special notation to combine the `system` and the `value` of the identifier in a single string. The convention is to concatenate the `system` and the `value` with a pipe `|`. The `system` is a URI that identifies the system that the identifier comes from. The `value` is the actual identifier value.
 
-## OAuth2 with a token
+## Machine-to-machine access
 
-For machine-to-machine API access, Tiro.health supports OAuth2 client credentials flow. This is the recommended authentication method for server-side integrations such as:
+The same API key authenticates machine-to-machine integrations — creating sessions via the [Session Management API](/api/session-management), background data synchronization with EHR/LIS systems, and automated workflows against the FHIR API.
 
-- Creating sessions programmatically via the Session Management API
-- Background data synchronization with EHR/LIS systems
-- Automated workflows that access FHIR resources
-
-OAuth2 provides token-based authentication where you exchange your client credentials (`client_id` and `client_secret`) for a temporary access token. The access token is then included in API requests using the `Authorization: Bearer` header.
-
-For detailed information on how to authenticate using OAuth2 client credentials, including code examples in multiple languages, see the **[API Authentication](/api/authentication)** guide.
+For code examples in multiple languages, see the **[API Authentication](/api/authentication)** guide.


### PR DESCRIPTION
## What I got wrong

In #75 I asserted that the old `/session` endpoint authenticated with an **OAuth2 bearer token**, and that migrating to `/sessions` meant switching to Basic auth. That is wrong — **authentication never changed.**

`POST /session` accepts the Basic API key on its own. The bearer path in `auth_server/session.py` is *optional*:

```python
if auth_session is None and user is None:
    raise HTTPException(401, "Invalid credentials")
elif auth_session is None and user is not None:
    auth_session = auth_session_to_auth_session_orm(auth_session_in, user)  # <- API-key user, no bearer
```

The API-key (`user`) branch is the one integrators actually take. I inferred the bearer story from what the docs claimed rather than from how the endpoint is really called, then wrote that inference back into the docs as fact.

## The docs were the source of the fiction

Chasing it down, the bearer flow isn't just absent from the session API — it doesn't work **anywhere**:

- `api/authentication` told integrators to exchange credentials at `POST /oauth/token` for an access token and send it as `Authorization: Bearer` on every request, claiming it "grants you access to all Tiro.health API endpoints".
- `/oauth/token` does exist — but what it returns is a `SessionTokenORM`, i.e. a **session handover token**, not an API access token. Its only consumer is the deprecated `session.py`.
- No endpoint accepts that token as an API credential. The FHIR API uses Basic/id-token; `/sessions` is API-key-only.

So the page documented a token you could obtain and then use nowhere.

## Changes

- **`api/session-management`** — remove the `Auth` row from the migration table and the "OAuth2 step disappears" paragraph; state plainly that authentication does not change.
- **`api/authentication`** — rewritten around the real mechanism: an API key (`client_id:client_secret`) over HTTP Basic, sent on every request, no token exchange. Drops the OAuth2 flow diagram, the token endpoint, the Bearer examples and the token cache/refresh managers. Adds the `X-User-Id` header, which is how a machine-to-machine request gets attributed to a practitioner.
- **`fhir/authentication`** — drop the "OAuth2 with a token" section that called the bearer flow "recommended" and linked to the page above.

Everything else from #75 stands — host (`auth.tiro.health`), paths, `handover_token` in the response body, and the `GET` handover were verified against the production OpenAPI schema and are unaffected.

## Verification

- Live OpenAPI schema on `auth.tiro.health`: `securitySchemes` are `HTTPBasic` and `HTTPBearer`; the session endpoints resolve the API key from Basic credentials (`get_api_key(basic_credentials, …)`).
- `tests/auth_server/test_sessions.py` authenticates every call with `Authorization: Basic`.
- `npm run build` passes; rewritten page rendered and confirmed to contain zero bearer/access-token references.

## Note

`/oauth/token` still exists in the schema. I have **not** documented or removed it — given it hands back a session token under an OAuth2-shaped wrapper, it's worth deciding separately whether it should exist at all. Flagging rather than guessing again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)