### PR TITLE
docs: Questionnaire url scope filter must use a version-less canonical URL

### DIFF
--- a/src/app/api/session-management/page.mdx
+++ b/src/app/api/session-management/page.mdx
@@ -585,13 +585,20 @@ You can narrow the delegation with filters on the scope (a Tiro.health extension
 
 ```text
 patient/Questionnaire.read?project=53
-patient/Questionnaire.read?url=https://templates.example.org/ct-scan|2.0.0
+patient/Questionnaire.read?url=https://templates.example.org/ct-scan
 patient/Questionnaire.read?specialty=urology
 ```
 
 - `project` — one of your service account's projects; other projects are ignored
-- `url` — a single template by canonical URL (optionally with `|version`)
+- `url` — a single template by canonical URL, **without** a `|version` suffix
 - `identifier`, `version`, `specialty` — further narrowing, combined with the project filter
+
+<Note>
+  Don't pin a version in the `url` filter (`url=https://templates.example.org/ct-scan|2.0.0`).
+  The template picker offers the latest active version of each template, so a session whose
+  scope pins any other version sees an **empty template list** rather than an error. Use the
+  bare canonical URL to restrict a session to a single template.
+</Note>
 
 Without filters, the user can choose from all templates in your service account's projects. If your account belongs to no projects, the session gets no template access — contact Tiro.health to link your API key to the right project.
 


### PR DESCRIPTION
## What

The Template Access and Filtering section of the session-management page showed a version-pinned canonical URL as the example `url` scope filter:

```text
patient/Questionnaire.read?url=https://templates.example.org/ct-scan|2.0.0
```

Testing against staging (sessions 12287 vs 12288 on 2026-07-27) shows that pinning a version silently yields an **empty template picker** when the pinned version isn't the latest active one the picker offers — the user sees no templates and no error. The bare canonical URL (`url=https://templates.tiro.health/templates/<id>`) correctly restricts the session to that single template, and the full launch → fill → submit → export round trip works under the narrowed scope.

## Changes

- Example now uses a version-less canonical URL
- The `url` bullet states the filter must not carry a `|version` suffix
- Added a `<Note>` explaining the empty-picker behavior when a version is pinned

If version pinning in the `url` filter is actually intended to work, this is a server bug instead — happy to close this in favour of a fix, but until then the docs shouldn't showcase a filter form that produces an empty picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)