### PR TITLE
docs: fix factual errors in FHIR reference pages

### DIFF
--- a/src/app/context/dotnet/page.mdx
+++ b/src/app/context/dotnet/page.mdx
@@ -90,7 +90,7 @@ Here is an example of how to create a session in a .NET application:
    string handoverToken = session.GetProperty("handover_token").GetString();
    ```
 
-2. Hand the token over to the WebView2 control by navigating it to the handover URL. The `next` value is the [Launch URL](/api/session-management#launch-url) the user should land on:
+2. Hand the token over to the WebView2 control by navigating it to the handover URL. The `next` value is the [Launch URL](/api/session-management#session-handover) the user should land on:
 
    ```csharp
    string nextUrl = Uri.EscapeDataString("https://app.tiro.health/external/v1?task=Task/123");

--- a/src/app/fhir/Encounter/page.mdx
+++ b/src/app/fhir/Encounter/page.mdx
@@ -6,11 +6,11 @@ export const metadata = {
 
 # Encounter
 
-Encounters are an essential part of Atticus. On this page, we’ll dive into the different encounter endpoints you can use to manage encounters programmatically. We'll look at how to query, create, update, and delete encounters. {{ className: 'lead' }}
+Encounters are an essential part of Atticus. On this page, we’ll dive into the different encounter endpoints you can use to manage encounters programmatically. We'll look at how to create, retrieve, update, and delete encounters. {{ className: 'lead' }}
 
 ## The Encounter model
 
-The Encounter model contains all the information about the encounters of a patient. In addition, encounters can also be group-based with more than one contact, they can have a pinned message, and they can be muted.
+The Encounter model contains all the information about the encounters of a patient.
 
 ### Properties
 
@@ -26,10 +26,10 @@ The Encounter model conforms to the FHIR Encounter resource. The following prope
     required
     href="https://hl7.org/fhir/R5/encounter-definitions.html#Encounter.status"
   >
-    The status of the encounter. Possible values are: - `planned` - `arrived` -
-    `triaged` - `in-progress` - `onleave` - `finished` - `cancelled` -
-    `entered-in-error` \ This is only stored as metadata and does not affect any
-    business logic.
+    The status of the encounter. Possible values are: - `planned` -
+    `in-progress` - `on-hold` - `discharged` - `completed` - `cancelled` -
+    `discontinued` - `entered-in-error` - `unknown` \ This is only stored as
+    metadata and does not affect any business logic.
   </Property>
   <Property
     name="identifier"
@@ -51,7 +51,11 @@ The Encounter model conforms to the FHIR Encounter resource. The following prope
   >
     A FHIR
     [`Reference`](https://hl7.org/fhir/R5/encounter-definitions.html#Encounter.subject)
-    object pointing to the patient which is the subject of the encounter.
+    object pointing to the patient which is the subject of the encounter. The
+    `reference` field must be a literal reference of the form `Patient/<id>`.
+    Identifier-only references and absolute URLs are rejected with a `422`
+    error. (Inside a transaction Bundle, a bundle-local `urn:uuid:` reference
+    is also accepted.)
   </Property>
 </Properties>
 ---
@@ -61,6 +65,13 @@ The Encounter model conforms to the FHIR Encounter resource. The following prope
 <Row>
   <Col>
     This endpoint allows you to create a new Encounter.
+
+    <Note>
+      Creating an Encounter whose `identifier` matches an existing Encounter
+      returns a `409 Conflict` with issue code `duplicate` and a `Location`
+      header pointing at the existing Encounter.
+    </Note>
+
   </Col>
   <Col sticky>
     <CodeGroup title="Request" tag="POST" label="/Encounter">
@@ -135,7 +146,7 @@ The Encounter model conforms to the FHIR Encounter resource. The following prope
         -H "Content-Type: application/fhir+json" \
         -d '{
           "resourceType": "Encounter",
-          "status": "entered-in-error",
+          "status": "in-progress",
           "subject": {
             "reference": "Patient/123"
           }
@@ -147,7 +158,7 @@ The Encounter model conforms to the FHIR Encounter resource. The following prope
         Authorization:"Basic {{apikey}}" \
         Content-Type:"application/fhir+json" \
         resourceType="Encounter" \
-        status="entered-in-error" \
+        status="in-progress" \
         subject:='{"reference": "Patient/123"}'
       ```
       
@@ -225,42 +236,33 @@ The Encounter model conforms to the FHIR Encounter resource. The following prope
 
 <Row>
   <Col>
-    This endpoint allows you to delete an existing Encounter by providing the Encounter id. Once an Encounter is deleted, it cannot be recovered.
+    This endpoint allows you to delete an existing Encounter by providing the
+    Encounter id. Once an Encounter is deleted, it cannot be recovered. A
+    successful delete returns a `204 No Content` response with an empty body.
   </Col>
   <Col sticky>
     <CodeGroup title="Request" tag="DELETE" label="/Encounter/1">
-      ```bash {{ title: 'cURL' }}
-      curl -X DELETE https://reports.tiro.health/fhir/r5/Encounter/1 \
-        -H "Authorization: Basic {{apikey}}" \
-        -H "Content-Type: application/fhir+json" \
-      ```
-      
-      ```bash {{ title: 'httpie' }}
-      http DELETE https://reports.tiro.health/fhir/r5/Encounter/1 \
-        Authorization:"Basic {{apikey}}" \
-        Content-Type:"application/fhir+json"
-      ```
-      
-      ```cs {{ title: 'C#' }}
-          var client = new FhirClient(new Uri("https://reports.tiro.health/fhir/r5"), settings, handler);
-          client.Delete("Encounter", "1");
-      ```
-      ```vb {{ title: 'VB.NET' }}
-          Dim client = New FhirClient(New Uri("https://reports.tiro.health/fhir/r5"), settings, handler)
-          client.Delete("Encounter", "1")
-      ```
+    ```bash {{ title: 'cURL' }}
+    curl -X DELETE https://reports.tiro.health/fhir/r5/Encounter/1 \
+      -H "Authorization: Basic {{apikey}}" \
+      -H "Content-Type: application/fhir+json" \
+    ```
+    ```bash {{ title: 'httpie' }}
+    http DELETE https://reports.tiro.health/fhir/r5/Encounter/1 \
+      Authorization:"Basic {{apikey}}" \
+      Content-Type:"application/fhir+json"
+    ```
+    ```cs {{ title: 'C#' }}
+    var client = new FhirClient(new Uri("https://reports.tiro.health/fhir/r5"), settings, handler);
+    client.Delete("Encounter", "1");
+    ```
+    ```vb {{ title: 'VB.NET' }}
+    Dim client = New FhirClient(New Uri("https://reports.tiro.health/fhir/r5"), settings, handler)
+    client.Delete("Encounter", "1")
+    ```
     </CodeGroup>
-    ```json {{ title: 'Response' }}
-    {
-      "resourceType": "OperationOutcome",
-      "issue": [
-        {
-          "severity": "information",
-          "code": "informational",
-          "diagnostics": "Successfully deleted Encounter/1"
-        }
-      ]
-    }
+    ```http {{ title: 'Response' }}
+    HTTP/1.1 204 No Content
     ```
   </Col>
 </Row>

--- a/src/app/fhir/Patient/page.mdx
+++ b/src/app/fhir/Patient/page.mdx
@@ -28,8 +28,10 @@ The Patient model conforms to the FHIR Patient resource. The following propertie
     An array of
     [`Identifier`](https://hl7.org/fhir/R5/datatypes.html#identifier) objects
     for this patient (e.g. MRN, SSN). This is the place to store EHR identifiers
-    or hospital identifiers for the patient. More information about identifiers
-    in Atticus can be found
+    or hospital identifiers for the patient. The API only accepts the `system`
+    and `value` fields (both required) on each identifier. Any other Identifier
+    field (`use`, `type`, `period`, `assigner`) is rejected with a `422`
+    validation error. More information about identifiers in Atticus can be found
     [here](./tips#store-your-internal-identifiers-in-fhir-resources).
   </Property>
   <Property
@@ -40,6 +42,10 @@ The Patient model conforms to the FHIR Patient resource. The following propertie
     The name of the patient. This includes given names and family name. Name
     contains an array of FHIR
     [`HumanName`](https://hl7.org/fhir/R5/datatypes.html#humanname) objects.
+    Only the first entry in the array is stored; additional entries are
+    discarded. Within a name, only `prefix`, `given`, `family`, and `text` are
+    used; other HumanName fields (`use`, `suffix`, `period`) are silently
+    ignored.
   </Property>
   <Property
     name="birthDate"
@@ -65,6 +71,13 @@ The Patient model conforms to the FHIR Patient resource. The following propertie
 <Row>
   <Col>
     This endpoint allows you to create a new Patient.
+
+    <Note>
+      Creating a patient whose `identifier` already exists in the tenant
+      returns `409 Conflict` with issue code `duplicate` and a `Location`
+      header pointing at the existing Patient.
+    </Note>
+
   </Col>
   <Col sticky>
     <CodeGroup title="Request" tag="POST" label="/Patient">
@@ -87,7 +100,7 @@ The Patient model conforms to the FHIR Patient resource. The following propertie
       }'
     ```
     ```cs {{ title: 'C#' }}
-    var client = new FhirClient(new Uri("https://reports.tiro.health.tiro.health/fhir/r5"), settings, handler);
+    var client = new FhirClient(new Uri("https://reports.tiro.health/fhir/r5"), settings, handler);
     var patient = new Patient
     {
       Name = new List<HumanName>
@@ -134,7 +147,14 @@ The Patient model conforms to the FHIR Patient resource. The following propertie
 <Row>
   <Col>
     This endpoint allows you to update a Patient by matching on specific criteria. The search criteria are provided as query parameters, and the updated Patient data is provided in the request body.
-    When no Patient is found that matches the search criteria, a **new Patient is created**.
+    The `?identifier=` query parameter is **required**: a bare `PUT /Patient` without it returns a `422`.
+    When no Patient is found that matches the search criteria, a **new Patient is created**; the response status is still `200 OK` (not `201`).
+
+    <Note>
+      Conditional PUT **merges** the submitted identifiers with the existing
+      ones, whereas `PUT /Patient/{id}` **replaces** the identifier list.
+    </Note>
+
   </Col>
   <Col sticky>
     <CodeGroup title="Request" tag="PUT" label="/Patient?identifier=http://hospital.example.org/identifiers/mrn|12345">
@@ -157,7 +177,7 @@ The Patient model conforms to the FHIR Patient resource. The following propertie
       }'
     ```
     ```cs {{ title: 'C#' }}
-    var client = new FhirClient(new Uri("https://reports.tiro.health.tiro.health/fhir/r5"), settings, handler);
+    var client = new FhirClient(new Uri("https://reports.tiro.health/fhir/r5"), settings, handler);
     var patient = new Patient
     {
       Name = new List<HumanName>
@@ -202,7 +222,7 @@ The Patient model conforms to the FHIR Patient resource. The following propertie
 
 <Row>
   <Col>
-    This endpoint allows you to update an existing Patient by providing both the Patient id and the updated Patient data. The entire Patient resource must be included in the request.
+    This endpoint allows you to update an existing Patient by providing both the Patient id and the updated Patient data. This is a partial update: omitted fields are left unchanged. The `identifier` list, when provided, replaces the existing list.
   </Col>
   <Col sticky>
     <CodeGroup title="Request" tag="PUT" label="/Patient/1">
@@ -226,7 +246,7 @@ The Patient model conforms to the FHIR Patient resource. The following propertie
       }'
     ```
     ```cs {{ title: 'C#' }}
-    var client = new FhirClient(new Uri("https://reports.tiro.health.tiro.health/fhir/r5"), settings, handler);
+    var client = new FhirClient(new Uri("https://reports.tiro.health/fhir/r5"), settings, handler);
     var patient = new Patient
     {
       Id = "1",
@@ -282,7 +302,7 @@ The Patient model conforms to the FHIR Patient resource. The following propertie
       -H "Content-Type: application/fhir+json" \
     ```
     ```cs {{ title: 'C#' }}
-    var client = new FhirClient(new Uri("https://reports.tiro.health.tiro.health/fhir/r5"), settings, handler);
+    var client = new FhirClient(new Uri("https://reports.tiro.health/fhir/r5"), settings, handler);
     var patient = client.Read<Patient>("1");
     ```
     </CodeGroup>
@@ -295,7 +315,10 @@ The Patient model conforms to the FHIR Patient resource. The following propertie
 
 <Row>
   <Col>
-    This endpoint allows you to delete an existing Patient by providing the Patient id. Once a Patient is deleted, it cannot be recovered.
+    This endpoint allows you to delete an existing Patient by providing the
+    Patient id. Once a Patient is deleted, it cannot be recovered. A successful
+    delete returns `204 No Content` with an empty body. If the patient is still
+    referenced by other resources, the request returns `409 Conflict`.
   </Col>
   <Col sticky>
     <CodeGroup title="Request" tag="DELETE" label="/Patient/1">
@@ -305,21 +328,12 @@ The Patient model conforms to the FHIR Patient resource. The following propertie
       -H "Content-Type: application/fhir+json" \
     ```
     ```cs {{ title: 'C#' }}
-    var client = new FhirClient(new Uri("https://reports.tiro.health.tiro.health/fhir/r5"), settings, handler);
+    var client = new FhirClient(new Uri("https://reports.tiro.health/fhir/r5"), settings, handler);
     client.Delete("Patient", "1");
     ```
     </CodeGroup>
-    ```json {{ title: 'Response' }}
-    {
-      "resourceType": "OperationOutcome",
-      "issue": [
-        {
-          "severity": "information",
-          "code": "informational",
-          "diagnostics": "Successfully deleted Patient/1"
-        }
-      ]
-    }
+    ```http {{ title: 'Response' }}
+    HTTP/1.1 204 No Content
     ```
   </Col>
 </Row>

--- a/src/app/fhir/QuestionnaireResponse/page.mdx
+++ b/src/app/fhir/QuestionnaireResponse/page.mdx
@@ -34,7 +34,9 @@ The QuestionnaireResponse model conforms to the FHIR QuestionnaireResponse resou
   <Property name="status" type="enum" required href='https://hl7.org/fhir/R5/questionnaireresponse-definitions.html#QuestionnaireResponse.status'>
         The status of the response. Possible values are:
         - `in-progress` (most common)
-        - `completed` (makes report read-only and triggers processing.) **Currently not allowed for external systems.**
+        - `completed`
+        - `amended`
+        - `entered-in-error`
   </Property>
   <Property name="subject" type="Reference" required href='https://hl7.org/fhir/R5/questionnaireresponse-definitions.html#QuestionnaireResponse.subject'>
       A FHIR [`Reference`](https://hl7.org/fhir/R5/references.html#Reference) object to the patient that is the subject of the response.
@@ -51,6 +53,11 @@ The QuestionnaireResponse model conforms to the FHIR QuestionnaireResponse resou
 <Row>
   <Col>
     This endpoint allows you to create a new QuestionnaireResponse.
+
+    <Note>
+      Posting a QuestionnaireResponse whose `identifier` already exists returns `409 Conflict` with issue code `conflict`. Unlike other resources, no `Location` header is returned and the issue code is not `duplicate`.
+    </Note>
+
   </Col>
   <Col sticky>
     <CodeGroup title="Request" tag="POST" label="/QuestionnaireResponse">
@@ -64,7 +71,7 @@ The QuestionnaireResponse model conforms to the FHIR QuestionnaireResponse resou
         "status": "in-progress",
         "identifier": [
           {
-            "system": "http://example.com/my-hospital-reports/,
+            "system": "http://example.com/my-hospital-reports/",
             "value": "123"
           }
         ],
@@ -77,7 +84,7 @@ The QuestionnaireResponse model conforms to the FHIR QuestionnaireResponse resou
       }'
     ```
     ```cs {{ title: 'C#' }}
-    var client = new FhirClient(new Uri("https://reports.tiro.health.tiro.health/fhir/r5"), settings, handler);
+    var client = new FhirClient(new Uri("https://reports.tiro.health/fhir/r5"), settings, handler);
     var qr = new QuestionnaireResponse
     {
         Status = QuestionnaireResponse.QuestionnaireResponseStatus.InProgress,
@@ -90,7 +97,7 @@ The QuestionnaireResponse model conforms to the FHIR QuestionnaireResponse resou
             Value = "123"
             }
         },
-        Subject = new ResourceReference("Patient/123")
+        Subject = new ResourceReference("Patient/123"),
         Encounter = new ResourceReference("Encounter/456")
     };
     client.Create(qr);
@@ -135,7 +142,7 @@ The QuestionnaireResponse model conforms to the FHIR QuestionnaireResponse resou
       -H "Content-Type: application/fhir+json" \
     ```
     ```cs {{ title: 'C#' }}
-    var client = new FhirClient(new Uri("https://reports.tiro.health.tiro.health/fhir/r5"), settings, handler);
+    var client = new FhirClient(new Uri("https://reports.tiro.health/fhir/r5"), settings, handler);
     var questionnaireResponse = client.Read<QuestionnaireResponse>("1");
     ```
     </CodeGroup>
@@ -169,6 +176,13 @@ The QuestionnaireResponse model conforms to the FHIR QuestionnaireResponse resou
 <Row>
   <Col>
     This endpoint allows you to delete an existing QuestionnaireResponse by providing the QuestionnaireResponse id. Once a QuestionnaireResponse is deleted, it cannot be recovered.
+
+    A successful deletion returns `204 No Content` with an empty body.
+
+    <Note>
+      Only the author (the API key or user that created the response) may delete it. Requests from anyone else return `403 Forbidden`. If the response is still referenced by another resource (for example as a Task output), the deletion returns `409 Conflict`.
+    </Note>
+
   </Col>
   <Col sticky>
     <CodeGroup title="Request" tag="DELETE" label="/QuestionnaireResponse/1">
@@ -178,21 +192,12 @@ The QuestionnaireResponse model conforms to the FHIR QuestionnaireResponse resou
       -H "Content-Type: application/fhir+json" \
     ```
     ```cs {{ title: 'C#' }}
-    var client = new FhirClient(new Uri("https://reports.tiro.health.tiro.health/fhir/r5"), settings, handler);
+    var client = new FhirClient(new Uri("https://reports.tiro.health/fhir/r5"), settings, handler);
     client.Delete("QuestionnaireResponse", "1");
     ```
     </CodeGroup>
-    ```json {{ title: 'Response' }}
-    {
-      "resourceType": "OperationOutcome",
-      "issue": [
-        {
-          "severity": "information",
-          "code": "informational",
-          "diagnostics": "Successfully deleted QuestionnaireResponse/1"
-        }
-      ]
-    }
+    ```http {{ title: 'Response' }}
+    HTTP/1.1 204 No Content
     ```
   </Col>
 </Row>

--- a/src/app/fhir/Task/page.mdx
+++ b/src/app/fhir/Task/page.mdx
@@ -41,14 +41,16 @@ The Task model conforms to the FHIR Task resource and implements the SDC Task Qu
         An array of identifiers for this task. This is useful for referencing tasks in external systems.
         More information about identifiers can be found [here](./tips#store-your-internal-identifiers-in-fhir-resources).
     </Property>
-    <Property name="status" type="code" href='https://hl7.org/fhir/R5/task-definitions.html#Task.status'>
+    <Property name="status" type="code" required href='https://hl7.org/fhir/R5/task-definitions.html#Task.status'>
     The current status of the task. Possible values include:
-    - `draft`: Task is created but not yet ready for action.\
-    This occurs when a `questionnaire` input is missing.
-    - `ready`: Task is ready to be completed by a practitioner.
+    - `draft`: Task is created but not yet ready for action.
+    - `ready`: Task is ready to be completed by a practitioner.\
+    Creating a task with this status requires a `questionnaire` input.
     - `in-progress`: Task is being worked on.
     The `questionnaire-response` output is available but may not be complete.
     - `completed`: Task has been completed successfully including the forwarding to other systesm like the EHR.
+    <span/>
+    On create, only `draft` and `ready` are accepted: `in-progress` and `completed` return `501 Not Implemented`, and `failed` returns `400`. Omitting the status returns a `422`.
     <span/>
     The status affects how the task appears in practitioners' worklists (the reports overview page) and is automatically updated as they interact with it.
     </Property>
@@ -61,7 +63,7 @@ The Task model conforms to the FHIR Task resource and implements the SDC Task Qu
     <Property name="input" type="BackboneElement[]" href='https://hl7.org/fhir/R5/task-definitions.html#Task.input'>
         Input parameters for the task. See [Task Inputs and Output Types](#input-and-output-types) section below for details on available input types.
 
-        Some parameters like `questionnaire` can be completed by a practitioner through the user interface.
+        Some parameters like `questionnaire` can be completed by a practitioner through the user interface. Note that inputs are only processed when the task is created with `status: "ready"`: a `questionnaire` input provided on a `draft` task is ignored and will not be visible when reading the task back.
     </Property>
     <Property name="output" type="BackboneElement[]" href='https://hl7.org/fhir/R5/task-definitions.html#Task.output'>
         Output parameters from the task execution. This captures the results produced by the task. This can only be added by the Tiro.health and should not be provided by the client.
@@ -131,9 +133,9 @@ Example of a task output containing a completed questionnaire response:
 
 The status of a Complete Questionnaire task progresses through several stages as practitioners interact with it:
 
-1. **`draft`** Task appears in practitioners' worklists as available for completion
-   The **questionnaire** input is optional, if provided the task status will be set to `ready` automatically.
-2. **`ready`** The **questionnaire** input is present either through the API or through the user interface. The task is ready to be fullfilled.
+1. **`draft`** Task appears in practitioners' worklists as available for completion.
+   A task created as `draft` stays `draft`, even when a **questionnaire** input is provided.
+2. **`ready`** The task was created with `status: "ready"` and a **questionnaire** input, or a practitioner selected a questionnaire through the user interface. The task is ready to be fullfilled.
 3. **`in-progress`** Practitioner has started filling out the questionnaire. A incomplete QuestionnairResponse is present in the output.
 4. **`completed`** Practitioner has successfully submitted the completed questionnaire. All processing steps have been full-filled.
 
@@ -148,6 +150,10 @@ Each status change affects how and where the task appears in the practitioner's 
 <Row>
     <Col>
         This endpoint allows you to create a new Complete Questionnaire task. The task will appear in practitioners' worklists based on the specified parameters.
+
+        <Note>
+            Posting a task whose body `identifier` already exists returns a `409 Conflict` (issue code `duplicate`) with a `Location` header pointing to the existing task. To create a task only if it doesn't exist yet, use a conditional create: `POST /Task?identifier=<token>` returns `200` with the existing task on a match, or `201` when a new task is created.
+        </Note>
     </Col>
     <Col sticky>
         <CodeGroup title="Request" tag="POST" label="/Task">
@@ -342,6 +348,7 @@ Dim task = client.Read(Of Task)("456")
   "intent": "order",
   "description": "Complete CT scan report for patient",
   "code": {
+    "text": "CT scan report",
     "coding": [
       {
         "system": "http://fhir.tiro.health/CodeSystem/task-type",
@@ -363,7 +370,7 @@ Dim task = client.Read(Of Task)("456")
           }
         ]
       },
-      "valueCanonical": "Questionnaire/ct-scan-report"
+      "valueCanonical": "https://tiro.health/fhir/Questionnaire/ct-scan-report|1.0.0"
     }
   ],
   "output": [
@@ -393,32 +400,37 @@ Dim task = client.Read(Of Task)("456")
 
 <Row>
 <Col>
-This endpoint allows you to search for tasks based on various criteria. This is useful for finding tasks for a specific patient or tasks of a certain status.
+This endpoint allows you to search for tasks based on various criteria. This is useful for finding tasks for a specific patient or tasks with a specific identifier.
 
-### Common search parameters
+### Supported search parameters
 
-- `status`: Filter tasks by status
-- `patient`: Filter tasks by patient reference
-- `code`: Filter tasks by type
 - `identifier`: Filter tasks by identifier
+- `code`: Filter tasks by type (use `code:text` to match on the code's `text`)
+- `subject`: Filter tasks by patient reference (e.g. `subject=Patient/123`)
+- `encounter`: Filter tasks by encounter reference
+- `output`: Filter tasks by output reference
+- `_id`: Filter tasks by resource id
+- `sort`, `offset`, `limit`: Control ordering and pagination of the results
+
+<Note>
+  Unsupported parameters (such as `status` or `patient`) are silently ignored
+  rather than rejected. A query containing only ignored parameters returns all
+  tasks in the tenant, up to the default limit of 1000.
+</Note>
 
 </Col>
 <Col sticky>
-<CodeGroup title="Request" tag="GET" label="/Task?patient=Patient/123&status=requested">
+<CodeGroup title="Request" tag="GET" label="/Task?subject=Patient/123">
   ```bash {{ title: 'cURL' }}
   curl -G https://reports.tiro.health/fhir/r5/Task \
-  --data-urlencode "patient=Patient/123" \
-  --data-urlencode "status=completed" \
-  --data-urlencode "code=complete-questionnaire" \
+  --data-urlencode "subject=Patient/123" \
   -H "Authorization: Basic {{apikey}}" \
   -H "Content-Type: application/fhir+json"
   ```
 
 ```bash {{ title: 'httpie' }}
 http GET https://reports.tiro.health/fhir/r5/Task \
-patient==Patient/123 \
-status==completed \
-code==complete-questionnaire \
+subject==Patient/123 \
 Authorization:"Basic {{apikey}}" \
 Content-Type:"application/fhir+json"
 ```
@@ -426,9 +438,7 @@ Content-Type:"application/fhir+json"
 ```cs {{ title: 'C#' }}
 var client = new FhirClient(new Uri("https://reports.tiro.health/fhir/r5"), settings, handler);
 var searchParams = new SearchParams()
-    .Where("patient=Patient/123")
-    .Where("status=completed")
-    .Where("code=complete-questionnaire");
+    .Where("subject=Patient/123");
 
 var results = client.Search<Task>(searchParams);
 ```
@@ -436,9 +446,7 @@ var results = client.Search<Task>(searchParams);
 ```vb {{ title: 'VB.NET' }}
 Dim client = New FhirClient(New Uri("https://reports.tiro.health/fhir/r5"), settings, handler)
 Dim searchParams = New SearchParams() _
-    .Where("patient=Patient/123") _
-    .Where("status=completed") _
-    .Where("code=complete-questionnaire")
+    .Where("subject=Patient/123")
 
 Dim results = client.Search(Of Task)(searchParams)
 ```
@@ -468,6 +476,7 @@ Dim results = client.Search(Of Task)(searchParams)
         "intent": "order",
         "description": "Complete CT scan report for patient",
         "code": {
+          "text": "CT scan report",
           "coding": [
             {
               "system": "http://fhir.tiro.health/CodeSystem/task-type",
@@ -475,7 +484,7 @@ Dim results = client.Search(Of Task)(searchParams)
             }
           ]
         },
-        "status": "requested",
+        "status": "ready",
         "for": {
           "reference": "Patient/123"
         },
@@ -489,7 +498,7 @@ Dim results = client.Search(Of Task)(searchParams)
                 }
               ]
             },
-            "valueCanonical": "Questionnaire/ct-scan-report"
+            "valueCanonical": "https://tiro.health/fhir/Questionnaire/ct-scan-report|1.0.0"
           }
         ]
       }

--- a/src/app/fhir/Transaction/page.mdx
+++ b/src/app/fhir/Transaction/page.mdx
@@ -28,7 +28,9 @@ A FHIR Bundle is a container for a collection of resources. When used for transa
     <Properties>
       <Property name="fullUrl" type="uri">
         A temporary UUID that can be used to reference the resource in other
-        entries.
+        entries. The value must literally match the format
+        `urn:uuid:<uuid>`. Using a FHIR-legal absolute URL as `fullUrl`
+        causes the whole Bundle to fail with a `422` error.
       </Property>
       <Property name="resource" type="Resource">
         The resource to be created, updated. Not required for DELETE operations.
@@ -37,8 +39,8 @@ A FHIR Bundle is a container for a collection of resources. When used for transa
         The request object contains the HTTP method and URL for the operation.
         <Properties>
           <Property name="method" type="code" required>
-            The HTTP method for the operation. Must be one of `POST`, `PUT`, or
-            `DELETE`.
+            The HTTP method for the operation. Must be one of `GET`, `POST`,
+            `PUT`, or `DELETE`.
           </Property>
           <Property name="url" type="string" required>
             The relative URL for the resource. For example, `Patient` or
@@ -100,7 +102,7 @@ specification](https://www.hl7.org/fhir/r5/bundle.html).
     ```
 
     ```cs {{ title: 'C#' }}
-    var client = new FhirClient(new Uri("https://reports.tiro.health.tiro.health/fhir/r5"), settings, handler);
+    var client = new FhirClient(new Uri("https://reports.tiro.health/fhir/r5"), settings, handler);
 
     var bundle = new Bundle
     {
@@ -149,15 +151,43 @@ specification](https://www.hl7.org/fhir/r5/bundle.html).
       "type": "transaction-response",
       "entry": [
         {
+          "resource": {
+            "resourceType": "Patient",
+            "id": "1",
+            "name": [{
+              "given": ["John"],
+              "family": "Smith"
+            }]
+          },
+          "link": [
+            {
+              "relation": "self",
+              "url": "Patient/1"
+            }
+          ],
           "response": {
-            "status": "201 Created",
-            "location": "Patient/1",
+            "status": "201",
+            "location": "Patient/1"
           }
         },
         {
+          "resource": {
+            "resourceType": "Encounter",
+            "id": "1",
+            "status": "in-progress",
+            "subject": {
+              "reference": "Patient/1"
+            }
+          },
+          "link": [
+            {
+              "relation": "self",
+              "url": "Encounter/1"
+            }
+          ],
           "response": {
-            "status": "201 Created",
-            "location": "Encounter/1",
+            "status": "201",
+            "location": "Encounter/1"
           }
         }
       ]
@@ -174,6 +204,15 @@ specification](https://www.hl7.org/fhir/r5/bundle.html).
 - The server processes the transaction atomically - either all operations succeed or none do
 - If any operation fails, the entire transaction is rolled back and an OperationOutcome is returned
 - References between resources in the transaction can use the temporary UUIDs specified in `fullUrl`
+- Only resources whose endpoints are transaction-enabled can appear in a bundle entry. Supported resources include `Patient`, `Encounter`, `Practitioner`, `Task`, `Questionnaire`, `QuestionnaireResponse`, `Binary` and `DocumentReference`, among others. An entry targeting an unsupported path (e.g. `PractitionerRole`, `Composition`) aborts the whole bundle with a "No matching route found" error.
+- `request.ifNoneExist` is accepted in the bundle but is not honored by any endpoint - conditional create silently degrades to a plain create (which may then return a `409` error on duplicate identifiers).
+
+<Note>
+  Response entries are returned in **execution order** - the server
+  topologically sorts entries by their `urn:uuid` dependencies - not in request
+  order. Do not correlate request entry N with response entry N positionally;
+  match on the returned `resource` or `response.location` instead.
+</Note>
 
 ## Common Use Cases
 
@@ -185,7 +224,7 @@ specification](https://www.hl7.org/fhir/r5/bundle.html).
 ## Response headers in a Bundle
 
 Most endpoints of the FHIR API use HTTP response headers to provide the exact location of a resource.
-The transaction response Bundle keeps these headers in the response object of the entry, which contains the status code and the location header.
+The transaction response Bundle keeps these headers in the entry: the `response` object contains the status code and the location header, and the `Link` headers are mapped to the entry's `link` array. Each successful entry also contains the full created or updated resource in `resource`. Response entries have no `fullUrl`.
 
 ```json
 {
@@ -193,9 +232,19 @@ The transaction response Bundle keeps these headers in the response object of th
   "type": "transaction-response",
   "entry": [
     {
-      "fullUrl": "https://reports.tiro.health/fhir/r5/QuestionnaireResponse/123",
+      "resource": {
+        "resourceType": "QuestionnaireResponse",
+        "id": "123",
+        "status": "in-progress"
+      },
+      "link": [
+        {
+          "relation": "self",
+          "url": "QuestionnaireResponse/123"
+        }
+      ],
       "response": {
-        "status": "201 Created",
+        "status": "201",
         "location": "QuestionnaireResponse/123"
       }
     }
@@ -217,7 +266,7 @@ If any operation in the transaction fails, the server will return an OperationOu
   "issue": [
     {
       "severity": "error",
-      "code": "processing",
+      "code": "exception",
       "diagnostics": "Transaction failed: Invalid resource in entry[0]"
     }
   ]

--- a/src/app/fhir/errors/page.mdx
+++ b/src/app/fhir/errors/page.mdx
@@ -6,7 +6,10 @@ export const metadata = {
 
 export const sections = [
   { title: 'Status codes', id: 'status-codes' },
-  { title: 'The OperationOutcome resource', id: 'the-operation-outcome-resource' },
+  {
+    title: 'The OperationOutcome resource',
+    id: 'the-operation-outcome-resource',
+  },
   { title: 'Issue codes', id: 'issue-codes' },
   { title: 'Common errors', id: 'common-errors' },
   { title: 'Handling errors in code', id: 'handling-errors-in-code' },
@@ -16,7 +19,7 @@ export const sections = [
 
 When something goes wrong while you work with the Atticus FHIR API, the response tells you what happened in two ways: the **HTTP status code** and a machine-readable **FHIR `OperationOutcome`** resource in the body. Together they let you detect, classify, and debug a failure programmatically before reaching out to support. {{ className: 'lead' }}
 
-You can tell whether a request succeeded from the HTTP status code. When a request fails, the `OperationOutcome` body carries one or more *issues* — each with a `severity`, a machine-readable `code`, and a human-readable `details.text` you can surface to your users or log.
+You can tell whether a request succeeded from the HTTP status code. When a request fails, the `OperationOutcome` body carries one or more _issues_ — each with a `severity`, a machine-readable `code`, and a human-readable `details.text` you can surface to your users or log.
 
 <Note>
   Surface `details.text` to your users (or at least your logs) rather than a
@@ -41,6 +44,11 @@ The API uses conventional HTTP status codes to indicate the outcome of a request
     (a malformed body, a missing resource, insufficient permissions, or a
     configuration problem). The `OperationOutcome` body explains what to fix.
   </Property>
+  <Property name="401 Unauthorized">
+    Authentication failed or is missing. Unlike other errors, the body is a
+    plain JSON object (`{"detail": "..."}`), not an `OperationOutcome` — handle
+    it before attempting to parse an `OperationOutcome`.
+  </Property>
   <Property name="5xx">
     A server error on our side. These are reported to our monitoring
     automatically; retry with backoff and contact support if they persist.
@@ -51,7 +59,7 @@ The API uses conventional HTTP status codes to indicate the outcome of a request
 
 ## The OperationOutcome resource
 
-Every error response on the FHIR API (`/fhir/r5`) returns a FHIR [`OperationOutcome`](https://hl7.org/fhir/R5/operationoutcome.html) resource. Its `issue` array always contains at least one entry.
+Nearly every error response on the FHIR API (`/fhir/r5`) returns a FHIR [`OperationOutcome`](https://hl7.org/fhir/R5/operationoutcome.html) resource; its `issue` array always contains at least one entry. The exceptions are authentication failures (`401`) and some search-parameter validation errors, which return a plain JSON body of the shape `{"detail": "..."}` instead.
 
 <Row>
   <Col>
@@ -82,7 +90,8 @@ Every error response on the FHIR API (`/fhir/r5`) returns a FHIR [`OperationOutc
       </Property>
       <Property name="issue[].expression" type="string[]">
         Optional FHIRPath expression(s) pointing at the element(s) at fault —
-        present on validation (`422`) errors.
+        present on validation errors (for example a `400` content-validation
+        failure on a submitted `QuestionnaireResponse`).
       </Property>
     </Properties>
 
@@ -113,19 +122,21 @@ Every error response on the FHIR API (`/fhir/r5`) returns a FHIR [`OperationOutc
 
 The `issue[].code` value classifies the failure and maps to the HTTP status below. Always branch on `code` rather than parsing `details.text`.
 
-| `code`         | HTTP status | Meaning |
-| -------------- | ----------- | ------- |
-| `invalid`       | `400 Bad Request` | The request is syntactically valid but references something that cannot be used — e.g. a questionnaire canonical that does not resolve to an active template. |
-| `multiple-matches` | `400 Bad Request` | A search expected to match a single resource matched several. Narrow your search parameters. |
-| `not-supported` | `400 Bad Request` | The requested operation or combination of parameters is not supported. |
-| `forbidden`     | `403 Forbidden` | You are authenticated but not allowed to access this resource (includes row-level access denials). |
-| `not-found`     | `404 Not Found` | The referenced resource does not exist or is not visible to you. |
-| `conflict`      | `409 Conflict` | The request conflicts with the current state of the resource. |
-| `duplicate`     | `409 Conflict` | A resource with the same unique identity already exists. The `Location` header points at the existing resource. |
-| `conflict`      | `412 Precondition Failed` | A conditional request failed because the resource changed since you last read it (`If-Match`/ETag). |
-| `required` / `business-rule` | `422 Unprocessable Content` | The resource failed validation. `expression` points at the offending element(s); for questionnaire responses this is a FHIRPath into the submitted resource. |
-| `not-supported` | `501 Not Implemented` | The operation is recognised but not yet implemented. |
-| `exception`     | `500 Internal Server Error` | An unexpected error on our side. Reported to monitoring automatically. |
+| `code`                       | HTTP status                 | Meaning                                                                                                                                                                                                                                                                                                        |
+| ---------------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `invalid`                    | `400 Bad Request`           | The request is syntactically valid but references something that cannot be used — e.g. a questionnaire canonical that does not resolve to an active template.                                                                                                                                                  |
+| `multiple-matches`           | `400 Bad Request`           | A search expected to match a single resource matched several. Narrow your search parameters.                                                                                                                                                                                                                   |
+| `not-supported`              | `400 Bad Request`           | The requested operation or combination of parameters is not supported.                                                                                                                                                                                                                                         |
+| `required` / `value`         | `400 Bad Request`           | A submitted resource failed content validation — e.g. a `QuestionnaireResponse` missing a required answer. `expression` points at the offending element(s) with a FHIRPath into the submitted resource.                                                                                                        |
+| `forbidden`                  | `403 Forbidden`             | You are authenticated but not allowed to access this resource (includes row-level access denials).                                                                                                                                                                                                             |
+| `not-found`                  | `404 Not Found`             | The referenced resource does not exist or is not visible to you.                                                                                                                                                                                                                                               |
+| `conflict`                   | `409 Conflict`              | The request conflicts with the current state of the resource.                                                                                                                                                                                                                                                  |
+| `duplicate`                  | `409 Conflict`              | A resource with the same unique identity already exists. For `Patient`, `Encounter`, and `Task` creates the `Location` header points at the existing resource; a duplicate-identifier `QuestionnaireResponse` create instead returns `conflict` with no `Location` header — don't branch on `duplicate` alone. |
+| `conflict`                   | `412 Precondition Failed`   | A conditional request failed because the resource changed since you last read it (`If-Match`/ETag).                                                                                                                                                                                                            |
+| `required` / `business-rule` | `422 Unprocessable Content` | The request body does not match the expected schema (shape) of the resource.                                                                                                                                                                                                                                   |
+| `not-supported`              | `501 Not Implemented`       | The operation is recognised but not yet implemented.                                                                                                                                                                                                                                                           |
+| `unknown`                    | `500 Internal Server Error` | An unexpected error on our side. Reported to monitoring automatically.                                                                                                                                                                                                                                         |
+| `exception`                  | `500 Internal Server Error` | Appears only on entry responses inside a [transaction/batch bundle](https://hl7.org/fhir/R5/http.html#transaction), accompanying a `500` or `422` entry status.                                                                                                                                                |
 
 ---
 
@@ -133,11 +144,11 @@ The `issue[].code` value classifies the failure and maps to the HTTP status belo
 
 ### Questionnaire (template) is not active or doesn't exist
 
-When you create or `$initialize` a **Complete Questionnaire** [Task](./Task), you reference the template through a *questionnaire canonical* — the template URL, optionally pinned to a version with a `|<version>` suffix (for example `…/0123456789abcdef0123456789abcdef|1.1.0`).
+When you create or `$initialize` a **Complete Questionnaire** [Task](./Task), you reference the template through a _questionnaire canonical_ — the template URL, optionally pinned to a version with a `|<version>` suffix (for example `…/0123456789abcdef0123456789abcdef|1.1.0`).
 
 If that **exact version** is no longer `active` — because it was retired or superseded by a newer publication — the canonical resolves to nothing and the API returns a `400` with `code: invalid` and a `details.text` naming the URL and version at fault (see the example above).
 
-**Why it happens.** A *version-pinned* canonical only resolves while that precise version is active. Publishing a new version of the template retires the old one, so any integration still configured with the old pinned version starts failing — typically surfacing to the end user as "the application can't be opened".
+**Why it happens.** A _version-pinned_ canonical only resolves while that precise version is active. Publishing a new version of the template retires the old one, so any integration still configured with the old pinned version starts failing — typically surfacing to the end user as "the application can't be opened".
 
 **How to fix it.** Configure a **version-independent** canonical by dropping the `|<version>` suffix; it always resolves to the latest active version of the template:
 
@@ -148,11 +159,11 @@ If that **exact version** is no longer `active` — because it was retired or su
 
 Pin a version only when you deliberately need a fixed historical template and you keep that version published.
 
-### Validation failures (422)
+### Validation failures (400)
 
-When a submitted resource (for example a `QuestionnaireResponse`) fails validation, the API returns `422 Unprocessable Content`. Each `issue` carries an `expression` with the FHIRPath to the offending element, so you can map the error back to the exact field:
+When a submitted resource (for example a `QuestionnaireResponse`) fails content validation on create or update, the API returns `400 Bad Request` with issue codes such as `required` and `value`. Each `issue` carries an `expression` with the FHIRPath to the offending element, so you can map the error back to the exact field. (`422 Unprocessable Content` is reserved for schema-level errors, where the request body itself does not match the expected resource shape.)
 
-```json {{ title: "Example validation error (422)" }}
+```json {{ title: "Example validation error (400)" }}
 {
   "resourceType": "OperationOutcome",
   "issue": [
@@ -160,7 +171,9 @@ When a submitted resource (for example a `QuestionnaireResponse`) fails validati
       "severity": "error",
       "code": "required",
       "details": { "text": "Field required" },
-      "expression": ["QuestionnaireResponse.item[0].answer[0].valueCoding.system"]
+      "expression": [
+        "QuestionnaireResponse.item[0].answer[0].valueCoding.system"
+      ]
     }
   ]
 }

--- a/src/app/fhir/page.mdx
+++ b/src/app/fhir/page.mdx
@@ -11,7 +11,7 @@ Tiro.health strives to give full control of the internals of Atticus through a s
 
 The following table gives an overview how concepts in Atticus are related to FHIR resources:
 
-| Attticus                | FHIR                                  | API Docs                                                  |
+| Atticus                 | FHIR                                  | API Docs                                                  |
 | ----------------------- | ------------------------------------- | --------------------------------------------------------- |
 | Subject                 | Patient                               | [Patient API](./fhir/Patient)                             |
 | Encounter               | Encounter                             | [Encounter API](./fhir/Encounter)                         |
@@ -19,3 +19,4 @@ The following table gives an overview how concepts in Atticus are related to FHI
 | Report (content)        | QuestionnaireResponse                 | [QuestionnaireResponse API](./fhir/QuestionnaireResponse) |
 | Template                | Questionnaire                         | Not yet documented                                        |
 | User                    | Practitioner                          | [Practitioner API](./fhir/Practitioner)                   |
+| Transactions            | Bundle (type: `transaction`)          | [Transaction API](./fhir/Transaction)                     |

--- a/src/app/fhir/tips/page.mdx
+++ b/src/app/fhir/tips/page.mdx
@@ -1,6 +1,7 @@
 export const metadata = {
   title: 'FHIR Tips',
-  description: 'This page contains tips and best practices for working with FHIR resources in Atticus.'
+  description:
+    'This page contains tips and best practices for working with FHIR resources in Atticus.',
 }
 
 # Tips for working with FHIR in Atticus
@@ -28,6 +29,14 @@ For example, you might want to use your hospital's patient ID to retrieve a pati
 
 ### Example of an `Identifier` object
 
+```json
+{
+  "system": "http://example.org/mrn",
+  "value": "12345"
+}
+```
+
+Note that only the `system` and `value` properties are accepted; other `Identifier` fields are rejected.
 
 ### Important rules
 


### PR DESCRIPTION
Fixes the factual errors identified in #82 across the `/fhir/*` reference pages. Every change was re-verified against the current backend (`origin/dev` @ `5d9392794`) before editing — see the issue for the original file-level evidence. (Supersedes #86, which was auto-closed by a branch rename.)

## Cross-cutting
- Replaced the phantom host `reports.tiro.health.tiro.health` with `reports.tiro.health` in all 9 C# examples (Patient ×5, QuestionnaireResponse ×3, Transaction ×1).
- DELETE sections (Patient, Encounter, QuestionnaireResponse) now show the real `204 No Content` empty-body response instead of a fabricated OperationOutcome with `diagnostics`.
- Documented the duplicate-identifier `409` on POST: `duplicate` + `Location` for Patient/Encounter/Task, and the divergent `conflict`-without-`Location` behavior for QuestionnaireResponse.

## Per page
- **Transaction**: response `status` is `"201"` (bare string); response entries carry `resource` + `link` but no `fullUrl` and come back in **execution order** (topological sort of `urn:uuid` deps) — added a Note warning against positional correlation; request `fullUrl` must be `urn:uuid:<uuid>` (absolute URLs 422 the whole bundle); listed transaction-enabled resources (`PractitionerRole`/`Composition` abort the bundle); `GET` entries supported; `ifNoneExist` accepted but not honored; error example issue code `processing` → `exception`.
- **Task**: search params corrected to the real set (`identifier`, `code`/`code:text`, `subject`, `encounter`, `output`, `_id`, paging) with a Note that unknown params (e.g. `status`, `patient`) are silently ignored; examples now use `subject=Patient/123`; response examples are producible (`code.text` present, `valueCanonical` in `url|version` form, no unemittable `requested` status); `status` marked required with create-time rules (`draft`/`ready` accepted, `in-progress`/`completed` → 501, `failed` → 400); corrected the false "questionnaire input flips a draft to ready" claim; documented conditional create (`POST /Task?identifier=` → 200/201).
- **Encounter**: R5 status value set (was R4 — `arrived`/`triaged`/`onleave`/`finished` are 422s); removed the "group-based / pinned message / muted" template boilerplate and the intro's "query" promise (there is no `GET /Encounter` search); made the conditional-update example internally consistent (request, C#/VB and response all `in-progress`); `subject.reference` must be a literal `Patient/<id>`.
- **Patient**: `identifier` accepts only `system`+`value` (anything else is a 422, not ignored); only `name[0]` is stored and only `prefix`/`given`/`family`/`text` are used; conditional PUT requires `?identifier=`, returns 200 even on create, and **merges** identifiers while `PUT /Patient/{id}` **replaces** them; `PUT /Patient/{id}` corrected to partial-update semantics.
- **QuestionnaireResponse**: fixed the invalid JSON in the create cURL (unterminated `"system"` string) and the missing comma in the C# sample; all four accepted statuses listed; removed the unenforced "completed … not allowed for external systems" claim; documented author-only DELETE (403 otherwise).
- **errors**: direct-request 500s carry `unknown` (`exception` only appears on transaction/batch entry outcomes); 401 returns a plain `{"detail": …}` body, not an OperationOutcome; QR content-validation failures are **400** (`required`/`value` + FHIRPath `expression`), 422 is schema-shape only; `duplicate`'s `Location` guarantee scoped to Patient/Encounter/Task.
- **tips**: added the missing `Identifier` example block. **index**: fixed the `Attticus` typo, added the Transaction row.

Also fixes the dangling `#launch-url` anchor in the .NET context guide (points to `#session-handover` now, since h3 headings get no id).

## Not in this PR
The coverage gaps from #82 — undocumented endpoints and features such as search sections, `$validate`, `$initialize`/`$start`/`$complete`, PATCH, ETag/`If-Match`, `_include`/`_revinclude`/`_elements`, narrative behavior, and Link headers — will be addressed in a follow-up PR. Two issue claims turned out stale during re-verification and are noted on the issue: the Transaction error example's `diagnostics` field is actually correct, and narrative regeneration on QR PUT was removed in the backend (`c5cb02cd9`).

Refs #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)